### PR TITLE
Exclude internal tools source code from Next analysis

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ sonar {
     property("sonar.projectKey", "SonarSource_sonar-rust")
     property("sonar.organization", "sonarsource")
     property("sonar.gradle.scanAll", "true")
-    property("sonar.exclusions", "**/build/**/*")
+    property("sonar.exclusions", "tools,**/build/**/*")
     property("sonar.links.ci", "https://cirrus-ci.com/github/SonarSource/sonar-rust")
     property("sonar.links.scm", "https://github.com/SonarSource/sonar-rust")
     property("sonar.links.issue", "https://jira.sonarsource.com/projects/SKUNK")


### PR DESCRIPTION
This PR updates the SonarQube configuration to exclude the source code of internal tools from Next analysis. These internal tools are essentially scripts that we occasionally run locally and are not part of the production code. By excluding these tools, we ensure that issues and coverage metrics from these scripts do not affect the project's quality gate.