### PR TITLE
SKUNK-21 Handle Rust native analyzer runtime failures gracefully

### DIFF
--- a/analyzer/src/analyze.rs
+++ b/analyzer/src/analyze.rs
@@ -5,7 +5,7 @@
  */
 use crate::{
     issue::{find_issues, Issue},
-    tree::parse_rust_code,
+    tree::{parse_rust_code, AnalyzerError},
     visitors::{
         cpd::{calculate_cpd_tokens, CpdToken},
         highlight::{highlight, HighlightToken},
@@ -21,15 +21,15 @@ pub struct Output {
     pub issues: Vec<Issue>,
 }
 
-pub fn analyze(source_code: &str) -> Output {
-    let tree = parse_rust_code(source_code);
+pub fn analyze(source_code: &str) -> Result<Output, AnalyzerError> {
+    let tree = parse_rust_code(source_code)?;
 
-    Output {
+    Ok(Output {
         highlight_tokens: highlight(&tree, source_code),
         metrics: calculate_metrics(&tree, source_code),
         cpd_tokens: calculate_cpd_tokens(&tree, source_code),
         issues: find_issues(&tree, source_code),
-    }
+    })
 }
 
 #[cfg(test)]
@@ -51,7 +51,7 @@ fn main() {
     println!("Hello, world!");
 }
         "#;
-        let output = analyze(source_code);
+        let output = analyze(source_code).unwrap();
 
         assert_eq!(
             output.metrics,
@@ -137,7 +137,7 @@ fn main() {
     fn test_unicode() {
         // 4 byte value
         assert_eq!(
-            analyze("//𠱓").highlight_tokens,
+            analyze("//𠱓").unwrap().highlight_tokens,
             vec![HighlightToken {
                 token_type: HighlightTokenType::Comment,
                 location: SonarLocation {
@@ -152,7 +152,7 @@ fn main() {
 
         // 3 byte unicode
         assert_eq!(
-            analyze("//ॷ").highlight_tokens,
+            analyze("//ॷ").unwrap().highlight_tokens,
             vec![HighlightToken {
                 token_type: HighlightTokenType::Comment,
                 location: SonarLocation {
@@ -167,7 +167,7 @@ fn main() {
 
         // 2 byte unicode
         assert_eq!(
-            analyze("//©").highlight_tokens,
+            analyze("//©").unwrap().highlight_tokens,
             vec![HighlightToken {
                 token_type: HighlightTokenType::Comment,
                 location: SonarLocation {
@@ -183,7 +183,7 @@ fn main() {
 
     #[test]
     fn test_multiple_unicode_locations() {
-        let mut actual = analyze("/*𠱓𠱓*/ //𠱓").highlight_tokens;
+        let mut actual = analyze("/*𠱓𠱓*/ //𠱓").unwrap().highlight_tokens;
         actual.sort();
 
         let mut expected = vec![
@@ -213,7 +213,7 @@ fn main() {
 
     #[test]
     fn test_multi_line_unicode() {
-        let mut actual = analyze("/*\n𠱓\n𠱓\n    𠱓*/").highlight_tokens;
+        let mut actual = analyze("/*\n𠱓\n𠱓\n    𠱓*/").unwrap().highlight_tokens;
         actual.sort();
 
         let mut expected = vec![HighlightToken {

--- a/analyzer/src/analyze.rs
+++ b/analyzer/src/analyze.rs
@@ -25,8 +25,8 @@ pub fn analyze(source_code: &str) -> Result<Output, AnalyzerError> {
     let tree = parse_rust_code(source_code)?;
 
     Ok(Output {
-        highlight_tokens: highlight(&tree, source_code),
-        metrics: calculate_metrics(&tree, source_code),
+        highlight_tokens: highlight(&tree, source_code)?,
+        metrics: calculate_metrics(&tree, source_code)?,
         cpd_tokens: calculate_cpd_tokens(&tree, source_code),
         issues: find_issues(&tree, source_code),
     })

--- a/analyzer/src/main.rs
+++ b/analyzer/src/main.rs
@@ -20,7 +20,7 @@ mod visitors {
 
 use analyze::analyze;
 use std::io::{self, Read, Write};
-use tree::SonarLocation;
+use tree::{AnalyzerError, ErrorKind, SonarLocation};
 
 fn main() {
     loop {
@@ -33,7 +33,25 @@ fn main() {
         let mut buf = vec![0u8; len as usize];
         io::stdin().read_exact(&mut buf).expect("read from stdin");
 
-        let output = analyze(std::str::from_utf8(&buf).expect("UTF-8 conversion error"));
+        let source_code = std::str::from_utf8(&buf).expect("UTF-8 conversion error");
+
+        let output = match analyze(source_code) {
+            Ok(output) => output,
+            Err(AnalyzerError {
+                message,
+                kind: ErrorKind::FileError,
+            }) => {
+                eprintln!("warn {}", message);
+                continue;
+            }
+            Err(AnalyzerError {
+                message,
+                kind: ErrorKind::GlobalError,
+            }) => {
+                eprintln!("error {}", message);
+                return;
+            }
+        };
 
         for token in &output.highlight_tokens {
             write_string("highlight");

--- a/analyzer/src/main.rs
+++ b/analyzer/src/main.rs
@@ -20,7 +20,7 @@ mod visitors {
 
 use analyze::analyze;
 use std::io::{self, Read, Write};
-use tree::{AnalyzerError, ErrorKind, SonarLocation};
+use tree::{AnalyzerError, SonarLocation};
 
 fn main() {
     loop {
@@ -37,17 +37,11 @@ fn main() {
 
         let output = match analyze(source_code) {
             Ok(output) => output,
-            Err(AnalyzerError {
-                message,
-                kind: ErrorKind::FileError,
-            }) => {
+            Err(AnalyzerError::FileError(message)) => {
                 eprintln!("warn {}", message);
                 continue;
             }
-            Err(AnalyzerError {
-                message,
-                kind: ErrorKind::GlobalError,
-            }) => {
+            Err(AnalyzerError::GlobalError(message)) => {
                 eprintln!("error {}", message);
                 return;
             }

--- a/analyzer/src/rules/parsing_error_check.rs
+++ b/analyzer/src/rules/parsing_error_check.rs
@@ -63,8 +63,8 @@ impl NodeVisitor for RuleVisitor<'_> {
             // Therefore, we only emit a generic parsing error message until the following ticket is fixed:
             // https://github.com/tree-sitter/tree-sitter/issues/255
             let message = "A syntax error occurred during parsing.".to_string();
-            let location = TreeSitterLocation::from_tree_sitter_node(node)
-                .to_sonar_location(&self.source_code);
+            let location =
+                TreeSitterLocation::from_tree_sitter_node(node).to_sonar_location(self.source_code);
 
             self.new_issue(message, location);
         }
@@ -79,8 +79,8 @@ impl NodeVisitor for RuleVisitor<'_> {
             // The Sonar location API expects the end column to be greater than the start column.
             // However, the end column of a missing node seems to be the same as the start column.
             // By precaution, we increment the end column by one to avoid potential failures.
-            let location = TreeSitterLocation::from_tree_sitter_node(node)
-                .to_sonar_location(&self.source_code);
+            let location =
+                TreeSitterLocation::from_tree_sitter_node(node).to_sonar_location(self.source_code);
             let sonar_location = SonarLocation {
                 end_column: if location.start_column == location.end_column {
                     location.start_column + 1
@@ -108,7 +108,7 @@ fn main() {
 }
 "#;
         let rule = ParsingErrorCheck::new();
-        let tree = parse_rust_code(source_code);
+        let tree = parse_rust_code(source_code).unwrap();
 
         let actual = rule.check(&tree, source_code);
         let expected = vec![];
@@ -126,7 +126,7 @@ fn main() {
 fn
 "#;
         let rule = ParsingErrorCheck::new();
-        let tree = parse_rust_code(source_code);
+        let tree = parse_rust_code(source_code).unwrap();
 
         let actual = rule.check(&tree, source_code);
         let expected = vec![

--- a/analyzer/src/visitors/cognitive_complexity.rs
+++ b/analyzer/src/visitors/cognitive_complexity.rs
@@ -3,7 +3,7 @@
  * All rights reserved
  * mailto:info AT sonarsource DOT com
  */
-use crate::tree::{walk_tree, NodeVisitor, TreeSitterLocation};
+use crate::tree::{walk_tree, AnalyzerError, NodeVisitor, TreeSitterLocation};
 use std::collections::HashSet;
 use tree_sitter::{Node, Tree};
 
@@ -13,19 +13,23 @@ pub(crate) struct Increment {
     nesting: i32,
 }
 
-pub(crate) fn calculate_total_cognitive_complexity(tree: &Tree) -> i32 {
-    calculate_cognitive_complexity(tree)
+pub(crate) fn calculate_total_cognitive_complexity(tree: &Tree) -> Result<i32, AnalyzerError> {
+    Ok(calculate_cognitive_complexity(tree)?
         .iter()
         .map(|inc| inc.nesting + 1)
-        .sum()
+        .sum())
 }
 
-fn calculate_cognitive_complexity(tree: &Tree) -> Vec<Increment> {
+fn calculate_cognitive_complexity(tree: &Tree) -> Result<Vec<Increment>, AnalyzerError> {
     let mut visitor = ComplexityVisitor::default();
 
     walk_tree(tree.root_node(), &mut visitor);
 
-    visitor.current_increments
+    if let Some(error) = visitor.error {
+        return Err(error);
+    }
+
+    Ok(visitor.current_increments)
 }
 
 #[derive(Default)]
@@ -34,6 +38,7 @@ struct ComplexityVisitor {
     visited_operators: HashSet<usize>,
     current_nesting: i32,
     current_enclosing_functions: i32,
+    error: Option<AnalyzerError>,
 }
 
 impl ComplexityVisitor {
@@ -85,15 +90,27 @@ impl NodeVisitor for ComplexityVisitor {
                 }
             }
             "binary_expression" if is_logical_operator(node) => {
-                let operator_token = node
-                    .child_by_field_name("operator")
-                    .expect("operator must be present in a binary expression");
+                let operator_token = match node.child_by_field_name("operator") {
+                    Some(token) => token,
+                    None => {
+                        self.error = Some(AnalyzerError::FileError(
+                            "operator must be present in binary expression".to_string(),
+                        ));
+                        return;
+                    }
+                };
 
                 if self.visited_operators.contains(&operator_token.id()) {
                     return;
                 }
 
-                let mut operators = flatten_operators(node);
+                let mut operators = match flatten_operators(node) {
+                    Ok(operators) => operators,
+                    Err(err) => {
+                        self.error = Some(err);
+                        return;
+                    }
+                };
                 let mut prev: Option<&str> = None;
 
                 while let Some(operator) = operators.pop() {
@@ -157,27 +174,29 @@ pub(crate) fn is_logical_operator(node: Node<'_>) -> bool {
     }
 }
 
-fn flatten_operators(node: Node<'_>) -> Vec<Node<'_>> {
-    let mut operators = vec![];
+fn flatten_operators(node: Node<'_>) -> Result<Vec<Node<'_>>, AnalyzerError> {
+    let mut operators: Vec<Node<'_>> = vec![];
 
     if let Some(left) = node.child_by_field_name("left") {
         if is_logical_operator(left) {
-            operators.extend(flatten_operators(left));
+            operators.extend(flatten_operators(left)?);
         }
     }
 
     operators.push(
         node.child_by_field_name("operator")
-            .expect("operator must be present in a binary expression"),
+            .ok_or(AnalyzerError::FileError(
+                "operator must be present in a binary expression".to_string(),
+            ))?,
     );
 
     if let Some(right) = node.child_by_field_name("right") {
         if is_logical_operator(right) {
-            operators.extend(flatten_operators(right));
+            operators.extend(flatten_operators(right)?);
         }
     }
 
-    operators
+    Ok(operators)
 }
 
 #[cfg(test)]
@@ -452,13 +471,13 @@ match x { // +1
 
     fn total_complexity(source_code: &str) -> i32 {
         let tree = parse_rust_code(format!("fn main() {{ {} }}", source_code).as_str()).unwrap();
-        calculate_total_cognitive_complexity(&tree)
+        calculate_total_cognitive_complexity(&tree).unwrap()
     }
 
     fn check_complexity(source_code: &str) {
         let tree = parse_rust_code(format!("fn main() {{ {} }}", source_code).as_str()).unwrap();
 
-        let increments = calculate_cognitive_complexity(&tree);
+        let increments = calculate_cognitive_complexity(&tree).unwrap();
         let mut expected_increments_by_line = collect_complexity_increments(source_code);
 
         let actual_total: i32 = increments.iter().map(|inc| inc.nesting + 1).sum();

--- a/analyzer/src/visitors/cognitive_complexity.rs
+++ b/analyzer/src/visitors/cognitive_complexity.rs
@@ -451,12 +451,12 @@ match x { // +1
     }
 
     fn total_complexity(source_code: &str) -> i32 {
-        let tree = parse_rust_code(format!("fn main() {{ {} }}", source_code).as_str());
+        let tree = parse_rust_code(format!("fn main() {{ {} }}", source_code).as_str()).unwrap();
         calculate_total_cognitive_complexity(&tree)
     }
 
     fn check_complexity(source_code: &str) {
-        let tree = parse_rust_code(format!("fn main() {{ {} }}", source_code).as_str());
+        let tree = parse_rust_code(format!("fn main() {{ {} }}", source_code).as_str()).unwrap();
 
         let increments = calculate_cognitive_complexity(&tree);
         let mut expected_increments_by_line = collect_complexity_increments(source_code);
@@ -490,7 +490,7 @@ match x { // +1
     }
 
     fn collect_complexity_increments(source_code: &str) -> Vec<IncrementLines> {
-        let tree = parse_rust_code(source_code);
+        let tree = parse_rust_code(source_code).unwrap();
         let query = Query::new(
             &tree_sitter_rust::LANGUAGE.into(),
             "(line_comment) @comment",

--- a/analyzer/src/visitors/cpd.rs
+++ b/analyzer/src/visitors/cpd.rs
@@ -54,7 +54,7 @@ impl NodeVisitor for CPDVisitor<'_> {
             self.tokens.push(CpdToken {
                 image: image.to_string(),
                 location: TreeSitterLocation::from_tree_sitter_node(node)
-                    .to_sonar_location(&self.source_code),
+                    .to_sonar_location(self.source_code),
             });
         }
     }
@@ -92,7 +92,7 @@ fn main() {
     42;
 }
 "#;
-        let tree = parse_rust_code(source_code);
+        let tree = parse_rust_code(source_code).unwrap();
 
         let actual = calculate_cpd_tokens(&tree, source_code);
         let expected = vec![

--- a/analyzer/src/visitors/cyclomatic_complexity.rs
+++ b/analyzer/src/visitors/cyclomatic_complexity.rs
@@ -137,7 +137,7 @@ mod tests {
     }
 
     fn complexity(source_code: &str) -> i32 {
-        let tree = parse_rust_code(source_code);
+        let tree = parse_rust_code(source_code).unwrap();
         calculate_cyclomatic_complexity(&tree)
     }
 }

--- a/analyzer/src/visitors/highlight.rs
+++ b/analyzer/src/visitors/highlight.rs
@@ -3,7 +3,7 @@
  * All rights reserved
  * mailto:info AT sonarsource DOT com
  */
-use crate::tree::{SonarLocation, TreeSitterLocation};
+use crate::tree::{AnalyzerError, SonarLocation, TreeSitterLocation};
 use std::collections::HashSet;
 use tree_sitter::{Node, Query, QueryCursor, StreamingIterator, Tree};
 
@@ -53,12 +53,14 @@ impl HighlightTokenType {
     }
 }
 
-pub fn highlight(tree: &Tree, source_code: &str) -> Vec<HighlightToken> {
+pub fn highlight(tree: &Tree, source_code: &str) -> Result<Vec<HighlightToken>, AnalyzerError> {
     let highlight_query = Query::new(
         &tree_sitter_rust::LANGUAGE.into(),
         tree_sitter_rust::HIGHLIGHTS_QUERY,
     )
-    .expect("Query parsing error");
+    .map_err(|err| {
+        AnalyzerError::GlobalError(format!("Failed to create highlight query: {}", err))
+    })?;
 
     let mut cursor = QueryCursor::new();
     let mut query_matches =
@@ -102,5 +104,5 @@ pub fn highlight(tree: &Tree, source_code: &str) -> Vec<HighlightToken> {
         });
     }
 
-    tokens
+    Ok(tokens)
 }

--- a/analyzer/src/visitors/metrics.rs
+++ b/analyzer/src/visitors/metrics.rs
@@ -117,7 +117,7 @@ fn main() {
     let x = "foo"; // Set 'x' to 'foo'
 }         
 "#;
-        let tree = parse_rust_code(source_code);
+        let tree = parse_rust_code(source_code).unwrap();
         let actual = calculate_metrics(&tree, source_code);
 
         assert_eq!(
@@ -143,7 +143,7 @@ fn main() {
     let x = "foo";
 }
 "#;
-        let tree = parse_rust_code(source_code);
+        let tree = parse_rust_code(source_code).unwrap();
         let actual = calculate_metrics(&tree, source_code);
 
         assert_eq!(
@@ -174,7 +174,7 @@ fn main() {
     let x = "foo";
 }
 "#;
-        let tree = parse_rust_code(source_code);
+        let tree = parse_rust_code(source_code).unwrap();
         let actual = calculate_metrics(&tree, source_code);
 
         assert_eq!(
@@ -216,7 +216,7 @@ fn main() {
     ; // Empty statement
 }
 "#;
-        let tree = parse_rust_code(source_code);
+        let tree = parse_rust_code(source_code).unwrap();
         let actual = calculate_metrics(&tree, source_code);
 
         assert_eq!(

--- a/analyzer/src/visitors/metrics.rs
+++ b/analyzer/src/visitors/metrics.rs
@@ -3,7 +3,7 @@
  * All rights reserved
  * mailto:info AT sonarsource DOT com
  */
-use crate::tree::{walk_tree, NodeVisitor};
+use crate::tree::{walk_tree, AnalyzerError, NodeVisitor};
 use crate::visitors::cognitive_complexity::calculate_total_cognitive_complexity;
 use crate::visitors::cyclomatic_complexity::calculate_cyclomatic_complexity;
 use std::collections::HashSet;
@@ -20,16 +20,16 @@ pub struct Metrics {
     pub cyclomatic_complexity: i32,
 }
 
-pub fn calculate_metrics(tree: &Tree, source_code: &str) -> Metrics {
+pub fn calculate_metrics(tree: &Tree, source_code: &str) -> Result<Metrics, AnalyzerError> {
     let mut metrics_visitor = MetricsVisitor::new(source_code);
     walk_tree(tree.root_node(), &mut metrics_visitor);
 
     let mut metrics = Metrics::default();
     metrics_visitor.update_metrics(&mut metrics);
-    metrics.cognitive_complexity = calculate_total_cognitive_complexity(tree);
+    metrics.cognitive_complexity = calculate_total_cognitive_complexity(tree)?;
     metrics.cyclomatic_complexity = calculate_cyclomatic_complexity(tree);
 
-    metrics
+    Ok(metrics)
 }
 
 #[derive(Debug)]
@@ -118,7 +118,7 @@ fn main() {
 }         
 "#;
         let tree = parse_rust_code(source_code).unwrap();
-        let actual = calculate_metrics(&tree, source_code);
+        let actual = calculate_metrics(&tree, source_code).unwrap();
 
         assert_eq!(
             actual,
@@ -144,7 +144,7 @@ fn main() {
 }
 "#;
         let tree = parse_rust_code(source_code).unwrap();
-        let actual = calculate_metrics(&tree, source_code);
+        let actual = calculate_metrics(&tree, source_code).unwrap();
 
         assert_eq!(
             actual,
@@ -175,7 +175,7 @@ fn main() {
 }
 "#;
         let tree = parse_rust_code(source_code).unwrap();
-        let actual = calculate_metrics(&tree, source_code);
+        let actual = calculate_metrics(&tree, source_code).unwrap();
 
         assert_eq!(
             actual,
@@ -217,7 +217,7 @@ fn main() {
 }
 "#;
         let tree = parse_rust_code(source_code).unwrap();
-        let actual = calculate_metrics(&tree, source_code);
+        let actual = calculate_metrics(&tree, source_code).unwrap();
 
         assert_eq!(
             actual,


### PR DESCRIPTION
After multiple rewrites, I settled with a simpler version that is not as intrusive as the other things I tried before. A few caveats:
- I kept the `expected` calls related to I/O: I think if they fail in the main analyzer, there is no way to recover and continue the process in a meaningful way.
- The coverage check is failing because I did not find a reproducible test case for some of the error cases. I still think it makes sense to recover and skip only the file, just in case someone finds an error case.
- After the ticket regarding the stdin/stdout communication on the Java side is done, we should detect the analyzer crashing, read stderr in the Java analyzer and emit appropriate log messages.