### PR TITLE
Fix cpd token computation and improve sensor error logs

### DIFF
--- a/sonar-rust-plugin/src/main/java/com/sonarsource/rust/plugin/RustSensor.java
+++ b/sonar-rust-plugin/src/main/java/com/sonarsource/rust/plugin/RustSensor.java
@@ -67,7 +67,7 @@ public class RustSensor implements Sensor {
       saveCPD(sensorContext, inputFile, result.cpdTokens());
       saveIssues(sensorContext, inputFile, result.issues());
     } catch (IOException ex) {
-      LOG.error("Failed to analyze file: {} ({})", inputFile.filename(), ex.getMessage());
+      LOG.error("Failed to analyze file: {}. Reason: {}", inputFile.filename(), ex.getMessage());
     }
   }
 
@@ -86,7 +86,7 @@ public class RustSensor implements Sensor {
         TextRange range = inputFile.newRange(token.startLine(), token.startColumn(), token.endLine(), token.endColumn());
         highlighting.highlight(range, TypeOfText.valueOf(token.tokenType()));
       } catch (IllegalArgumentException e) {
-        LOG.error("Invalid highlighting: {}", e.getMessage());
+        LOG.error("Invalid highlighting: {}. Reason: {}", token, e.getMessage());
       }
     }
     highlighting.save();
@@ -115,7 +115,7 @@ public class RustSensor implements Sensor {
       try {
         newCpdTokens.addToken(token.startLine(), token.startColumn(), token.endLine(), token.endColumn(), token.image());
       } catch (IllegalArgumentException e) {
-        LOG.error("Invalid CPD token: {}", e.getMessage());
+        LOG.error("Invalid CPD token: {}. Reason: {}", token, e.getMessage());
       }
     }
     newCpdTokens.save();
@@ -134,7 +134,7 @@ public class RustSensor implements Sensor {
           .at(location)
           .save();
       } catch (IllegalArgumentException e) {
-        LOG.error("Invalid issue: {}", e.getMessage());
+        LOG.error("Invalid issue: {}. Reason: {}", issue, e.getMessage());
       }
     }
   }


### PR DESCRIPTION
There were two issues that caused failures when saving CPD tokens using the Sonar plugin API. Both problems relate to one-liner tokens that have the same starting and ending columns:

- **Empty source files**: We incorrectly assumed that AST nodes without children would be tokens, resulting in the emission of a malformed token for empty source file nodes.
- **Empty raw string literals**: A raw string literal consists of a child node of the kind `string_content`. When the string content is empty, it leads to invalid locations, which we then emitted.

I double-checked this fix using the `rust-clippy` and `zed` projects that we analyze on Peach. All error messages regarding invalid CPD tokens are now gone.

> FYI, I used this opportunity to enhance the error logs generated by the sensor to assist in troubleshooting failures. Previously, we were only indicating that a token or issue was invalid without providing any additional details except some stack trace.