### PR TITLE
Remove redundancy in Clippy sensor names

### DIFF
--- a/sonar-rust-plugin/src/main/java/com/sonarsource/rust/clippy/ClippyReportSensor.java
+++ b/sonar-rust-plugin/src/main/java/com/sonarsource/rust/clippy/ClippyReportSensor.java
@@ -26,7 +26,7 @@ public class ClippyReportSensor implements Sensor {
   @Override
   public void describe(SensorDescriptor descriptor) {
     descriptor
-      .name("Clippy Report Import Sensor")
+      .name("Clippy Report Import")
       .onlyOnLanguage(RustLanguage.KEY)
       .onlyWhenConfiguration(config -> config.hasKey(CLIPPY_REPORT_PATHS));
   }

--- a/sonar-rust-plugin/src/main/java/com/sonarsource/rust/clippy/ClippySensor.java
+++ b/sonar-rust-plugin/src/main/java/com/sonarsource/rust/clippy/ClippySensor.java
@@ -36,7 +36,7 @@ public class ClippySensor implements Sensor {
   @Override
   public void describe(SensorDescriptor descriptor) {
     descriptor
-      .name("Clippy Sensor")
+      .name("Clippy")
       .onlyWhenConfiguration(config -> config.getBoolean(CLIPPY_SENSOR_ENABLED).orElse(true))
       .onlyOnLanguage(RustLanguage.KEY);
   }

--- a/sonar-rust-plugin/src/test/java/com/sonarsource/rust/clippy/ClippyReportSensorTest.java
+++ b/sonar-rust-plugin/src/test/java/com/sonarsource/rust/clippy/ClippyReportSensorTest.java
@@ -34,7 +34,7 @@ class ClippyReportSensorTest {
     var descriptor = new DefaultSensorDescriptor();
     sensor.describe(descriptor);
 
-    assertThat(descriptor.name()).isEqualTo("Clippy Report Import Sensor");
+    assertThat(descriptor.name()).isEqualTo("Clippy Report Import");
     assertThat(descriptor.languages()).containsOnly(RustLanguage.KEY);
     assertThat(descriptor.configurationPredicate()).isNotNull();
   }

--- a/sonar-rust-plugin/src/test/java/com/sonarsource/rust/clippy/ClippySensorTest.java
+++ b/sonar-rust-plugin/src/test/java/com/sonarsource/rust/clippy/ClippySensorTest.java
@@ -38,7 +38,7 @@ class ClippySensorTest {
     var descriptor = new DefaultSensorDescriptor();
     sensor.describe(descriptor);
 
-    assertThat(descriptor.name()).isEqualTo("Clippy Sensor");
+    assertThat(descriptor.name()).isEqualTo("Clippy");
     assertThat(descriptor.languages()).containsOnly(RustLanguage.KEY);
   }
 


### PR DESCRIPTION
The term `Sensor` is redundant in the registered name.
When running the scanner, one will see `Sensor Clippy Sensor`.