### PR TITLE
SKUNK-34 SKUNK-35 Add checks for Cargo and Clippy availability

### DIFF
--- a/sonar-rust-plugin/src/main/java/com/sonarsource/rust/clippy/ClippyPrerequisite.java
+++ b/sonar-rust-plugin/src/main/java/com/sonarsource/rust/clippy/ClippyPrerequisite.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2025 SonarSource SA
+ * All rights reserved
+ * mailto:info AT sonarsource DOT com
+ */
+package com.sonarsource.rust.clippy;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ClippyPrerequisite {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ClippyPrerequisite.class);
+
+  private final ProcessWrapper processWrapper;
+
+  public ClippyPrerequisite() {
+    this(new ProcessWrapper());
+  }
+
+  public ClippyPrerequisite(ProcessWrapper processWrapper) {
+    this.processWrapper = processWrapper;
+  }
+
+  public void check(Path workDir) {
+    checkVersion(List.of("cargo", "--version"), "Cargo", workDir);
+    checkVersion(List.of("cargo", "clippy", "--version"), "Clippy", workDir);
+  }
+
+  private void checkVersion(List<String> command, String prerequisite, Path workDir) {
+    LOG.debug("Checking {} version", prerequisite);
+    try {
+      processWrapper.start(command, workDir);
+      try (var reader = new BufferedReader(new InputStreamReader(processWrapper.getInputStream()))) {
+        var version = reader.readLine();
+        LOG.debug("{} version: {}", prerequisite, version);
+      }
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to check " + prerequisite + " version", e);
+    }
+  }
+}

--- a/sonar-rust-plugin/src/test/java/com/sonarsource/rust/clippy/ClippyPrerequisiteTest.java
+++ b/sonar-rust-plugin/src/test/java/com/sonarsource/rust/clippy/ClippyPrerequisiteTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2025 SonarSource SA
+ * All rights reserved
+ * mailto:info AT sonarsource DOT com
+ */
+package com.sonarsource.rust.clippy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.event.Level;
+import org.sonar.api.testfixtures.log.LogTesterJUnit5;
+
+class ClippyPrerequisiteTest {
+
+  @RegisterExtension
+  final LogTesterJUnit5 logTester = new LogTesterJUnit5().setLevel(Level.DEBUG);
+
+  @Test
+  void testSuccess() throws Exception {
+    var process = mock(ProcessWrapper.class);
+    var clippyPrerequisite = new ClippyPrerequisite(process);
+    var workDir = Path.of("some/dir");
+
+    when(process.getInputStream())
+      .thenReturn(new ByteArrayInputStream("cargo 1.0.0".getBytes()))
+      .thenReturn(new ByteArrayInputStream("clippy 1.0.0".getBytes()));
+
+    clippyPrerequisite.check(workDir);
+
+    verify(process).start(List.of("cargo", "--version"), workDir);
+    verify(process).start(List.of("cargo", "clippy", "--version"), workDir);
+
+    assertThat(logTester.logs()).contains(
+      "Checking Cargo version",
+      "Cargo version: cargo 1.0.0",
+      "Checking Clippy version",
+      "Clippy version: clippy 1.0.0");
+  }
+
+  @Test
+  void testFailure() throws Exception {
+    var processWrapper = mock(ProcessWrapper.class);
+    var clippyPrerequisite = new ClippyPrerequisite(processWrapper);
+    var workDir = Path.of("some/dir");
+
+    doThrow(new IOException("error")).when(processWrapper).start(any(), any());
+
+    var exception = assertThrows(IllegalStateException.class, () -> clippyPrerequisite.check(workDir));
+    assertThat(exception).hasMessageContaining("Failed to check Cargo version");
+  }
+}

--- a/sonar-rust-plugin/src/test/java/com/sonarsource/rust/clippy/ClippySensorTest.java
+++ b/sonar-rust-plugin/src/test/java/com/sonarsource/rust/clippy/ClippySensorTest.java
@@ -8,6 +8,7 @@ package com.sonarsource.rust.clippy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -54,6 +55,9 @@ class ClippySensorTest {
       .build();
     context.fileSystem().add(inputFile);
 
+    ClippyPrerequisite clippyPrerequisite = mock(ClippyPrerequisite.class);
+    doNothing().when(clippyPrerequisite).check(any());
+
     ClippyRunner clippyRunner = mock(ClippyRunner.class);
     when(clippyRunner.run(any(), any())).thenReturn(List.of(
       new ClippyDiagnostic(new ClippyMessage(
@@ -71,7 +75,7 @@ class ClippySensorTest {
         "message",
         List.of(new ClippySpan("excluded.rs", 1, 2, 1, 4))))
     ));
-    ClippySensor sensor = new ClippySensor(clippyRunner);
+    ClippySensor sensor = new ClippySensor(clippyPrerequisite, clippyRunner);
     sensor.execute(context);
 
     ArgumentCaptor<Path> pathCaptor = forClass(Path.class);


### PR DESCRIPTION
I initially intended to include the availability check in the Clippy runner; however, this complicated the corresponding unit tests. As a result, I decided to create a separate class for checking Clippy prerequisites. This approach may prove useful later if we want the analysis to fail for Cargo and Clippy versions that are below a certain version. Please let me know if this is acceptable or if I should make an additional effort to include these checks in the runner instead.

For your information, I used a local SonarQube instance to validate that these checks behave as expected.

- **Failure**
    ```
    15:06:30.473 INFO  Sensor Clippy Sensor [rust]
    15:06:30.474 DEBUG Checking Cargo version
    15:06:30.539 DEBUG Cargo version: cargo 1.87.0-nightly (1d1d646c0 2025-02-21)
    15:06:30.539 DEBUG Checking Clippy version
    15:06:30.551 ERROR Failed to check Clippy prerequisites
    java.lang.IllegalStateException: Failed to check Clippy version
    ```
- **Success**
    ```
    15:17:28.523 INFO  Sensor Clippy Sensor [rust]
    15:17:28.523 DEBUG Checking Cargo version
    15:17:28.586 DEBUG Cargo version: cargo 1.87.0-nightly (1d1d646c0 2025-02-21)
    15:17:28.586 DEBUG Checking Clippy version
    15:17:28.679 DEBUG Clippy version: clippy 0.1.86 (00f245915b 2025-02-26)
    ```