### PR TITLE
SKUNK-26 Add CI for MacOS builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -109,7 +109,7 @@ macos_arm64_task:
         cpu: 4
         memory: 8G
   install_script:
-    - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+    - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
     - brew install SergioBenitez/osxct/x86_64-unknown-linux-gnu
     - brew install filosottile/musl-cross/musl-cross
     - brew install mingw-w64

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -70,6 +70,8 @@ win_ssd_and_clone: &WIN_SSD_AND_CLONE
     fi
 
 build_task:
+  depends_on:
+    - macos_arm64
   eks_container:
     <<: *CONTAINER_DEFINITION
     cpu: 4
@@ -90,6 +92,9 @@ build_task:
     ARTIFACTORY_DEPLOY_USERNAME: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-qa-deployer username]
     ARTIFACTORY_DEPLOY_PASSWORD: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-qa-deployer access_token]
     DEPLOY_PULL_REQUEST: "true"
+  download_script:
+    - mkdir -p "analyzer/target/aarch64-apple-darwin/release"
+    - curl -o "analyzer/target/aarch64-apple-darwin/release/analyzer" http://${CIRRUS_HTTP_CACHE_HOST}/build/${CIRRUS_BUILD_ID}/analyzer
   build_script:
     - source cirrus-env BUILD-PRIVATE
     - source .cirrus/use-gradle-wrapper.sh
@@ -115,22 +120,16 @@ macos_arm64_task:
     - HOMEBREW_NO_INSTALL_CLEANUP: 1
   gradle_cache:
     folder: ".gradle"
-  brew_cache:
-    # retrieve this value by running `brew --cache` on a macOS machine
-    folder: "/Users/admin/Library/Caches/Homebrew"
   install_script:
     - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
     - . $HOME/.cargo/env
-    - brew install SergioBenitez/osxct/x86_64-unknown-linux-gnu
-    - brew install filosottile/musl-cross/musl-cross
-    - brew install mingw-w64
-    - rustup target add x86_64-pc-windows-gnu x86_64-unknown-linux-musl x86_64-unknown-linux-gnu x86_64-apple-darwin
+    - rustup target add x86_64-apple-darwin
     - rustup component add clippy
   build_script:
     - echo "org.gradle.daemon=false" >> "gradle.properties"
     - echo "org.gradle.vfs.watch=false" >> "gradle.properties"
     - . $HOME/.cargo/env
-    - ./gradlew build --info --stacktrace
+    - ./gradlew :analyzer:compileRustDarwin --info --stacktrace
   upload_script:
     - curl -X POST --data-binary @analyzer/target/aarch64-apple-darwin/release/analyzer http://${CIRRUS_HTTP_CACHE_HOST}/build/${CIRRUS_BUILD_ID}/analyzer
   plugin_artifacts:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -113,11 +113,6 @@ macos_arm64_task:
         image: ghcr.io/cirruslabs/macos-sonoma-xcode:latest
         cpu: 4
         memory: 8G
-  env:
-    - HOMEBREW_NO_AUTO_UPDATE: 1
-    - HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
-    - HOMEBREW_NO_INSTALL_UPGRADE: 1
-    - HOMEBREW_NO_INSTALL_CLEANUP: 1
   gradle_cache:
     folder: ".gradle"
   install_script:
@@ -132,8 +127,7 @@ macos_arm64_task:
     - ./gradlew :analyzer:compileRustDarwin --info --stacktrace
   upload_script:
     - curl -X POST --data-binary @analyzer/target/aarch64-apple-darwin/release/analyzer http://${CIRRUS_HTTP_CACHE_HOST}/build/${CIRRUS_BUILD_ID}/analyzer
-  plugin_artifacts:
-    path: "sonar-rust-plugin/build/libs/**"
+  <<: *CLEANUP_GRADLE_CACHE_SCRIPT
 
 e2e_task:
   depends_on:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -115,8 +115,9 @@ macos_arm64_task:
     - HOMEBREW_NO_INSTALL_CLEANUP: 1
   gradle_cache:
     folder: ".gradle"
-  read_brew_script:
-    - brew --cache
+  brew_cache:
+    # retrieve this value by running `brew --cache` on a macOS machine
+    folder: "/Users/admin/Library/Caches/Homebrew"
   install_script:
     - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
     - . $HOME/.cargo/env

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -131,6 +131,8 @@ macos_arm64_task:
     - echo "org.gradle.vfs.watch=false" >> "gradle.properties"
     - . $HOME/.cargo/env
     - ./gradlew build --info --stacktrace
+  upload_script:
+    - curl -X POST --data-binary @analyzer/target/aarch64-apple-darwin/release/analyzer http://${CIRRUS_HTTP_CACHE_HOST}/build/${CIRRUS_BUILD_ID}/analyzer
   plugin_artifacts:
     path: "sonar-rust-plugin/build/libs/**"
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -119,7 +119,6 @@ macos_arm64_task:
     - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
     - . $HOME/.cargo/env
     - rustup target add x86_64-apple-darwin
-    - rustup component add clippy
   build_script:
     - echo "org.gradle.daemon=false" >> "gradle.properties"
     - echo "org.gradle.vfs.watch=false" >> "gradle.properties"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -125,7 +125,7 @@ macos_arm64_task:
     - echo "org.gradle.daemon=false" >> "gradle.properties"
     - echo "org.gradle.vfs.watch=false" >> "gradle.properties"
     - . $HOME/.cargo/env
-    - ./gradlew :analyzer:compileRustDarwin --info --stacktrace
+    - ./gradlew :analyzer:compileRustDarwin :analyzer:compileRustDarwinX86 --info --stacktrace
   upload_script:
     - curl -X POST --data-binary @analyzer/target/aarch64-apple-darwin/release/analyzer http://${CIRRUS_HTTP_CACHE_HOST}/build/${CIRRUS_BUILD_ID}/aarch64-apple-darwin
     - curl -X POST --data-binary @analyzer/target/x86_64-apple-darwin/release/analyzer http://${CIRRUS_HTTP_CACHE_HOST}/build/${CIRRUS_BUILD_ID}/x86_64-apple-darwin

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -94,7 +94,9 @@ build_task:
     DEPLOY_PULL_REQUEST: "true"
   download_script:
     - mkdir -p "analyzer/target/aarch64-apple-darwin/release"
-    - curl -o "analyzer/target/aarch64-apple-darwin/release/analyzer" http://${CIRRUS_HTTP_CACHE_HOST}/build/${CIRRUS_BUILD_ID}/analyzer
+    - curl -o "analyzer/target/aarch64-apple-darwin/release/analyzer" http://${CIRRUS_HTTP_CACHE_HOST}/build/${CIRRUS_BUILD_ID}/aarch64-apple-darwin
+    - mkdir -p "analyzer/target/x86_64-apple-darwin/release"
+    - curl -o "analyzer/target/x86_64-apple-darwin/release/analyzer" http://${CIRRUS_HTTP_CACHE_HOST}/build/${CIRRUS_BUILD_ID}/x86_64-apple-darwin
   build_script:
     - source cirrus-env BUILD-PRIVATE
     - source .cirrus/use-gradle-wrapper.sh
@@ -125,7 +127,8 @@ macos_arm64_task:
     - . $HOME/.cargo/env
     - ./gradlew :analyzer:compileRustDarwin --info --stacktrace
   upload_script:
-    - curl -X POST --data-binary @analyzer/target/aarch64-apple-darwin/release/analyzer http://${CIRRUS_HTTP_CACHE_HOST}/build/${CIRRUS_BUILD_ID}/analyzer
+    - curl -X POST --data-binary @analyzer/target/aarch64-apple-darwin/release/analyzer http://${CIRRUS_HTTP_CACHE_HOST}/build/${CIRRUS_BUILD_ID}/aarch64-apple-darwin
+    - curl -X POST --data-binary @analyzer/target/x86_64-apple-darwin/release/analyzer http://${CIRRUS_HTTP_CACHE_HOST}/build/${CIRRUS_BUILD_ID}/x86_64-apple-darwin
   <<: *CLEANUP_GRADLE_CACHE_SCRIPT
 
 e2e_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -93,10 +93,13 @@ build_task:
     ARTIFACTORY_DEPLOY_PASSWORD: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-qa-deployer access_token]
     DEPLOY_PULL_REQUEST: "true"
   download_script:
-    - mkdir -p "analyzer/target/aarch64-apple-darwin/release"
-    - curl -o "analyzer/target/aarch64-apple-darwin/release/analyzer" http://${CIRRUS_HTTP_CACHE_HOST}/build/${CIRRUS_BUILD_ID}/aarch64-apple-darwin
-    - mkdir -p "analyzer/target/x86_64-apple-darwin/release"
-    - curl -o "analyzer/target/x86_64-apple-darwin/release/analyzer" http://${CIRRUS_HTTP_CACHE_HOST}/build/${CIRRUS_BUILD_ID}/x86_64-apple-darwin
+    - >
+      if [[ $CIRRUS_BRANCH == "master" || $CIRRUS_BRANCH == "dogfood-on-peach" || $CIRRUS_BRANCH =~ ^branch-.* ]]; then
+        mkdir -p "analyzer/target/aarch64-apple-darwin/release"
+        curl -o "analyzer/target/aarch64-apple-darwin/release/analyzer" http://${CIRRUS_HTTP_CACHE_HOST}/build/${CIRRUS_BUILD_ID}/aarch64-apple-darwin
+        mkdir -p "analyzer/target/x86_64-apple-darwin/release"
+        curl -o "analyzer/target/x86_64-apple-darwin/release/analyzer" http://${CIRRUS_HTTP_CACHE_HOST}/build/${CIRRUS_BUILD_ID}/x86_64-apple-darwin
+      fi
   build_script:
     - source cirrus-env BUILD-PRIVATE
     - source .cirrus/use-gradle-wrapper.sh
@@ -104,7 +107,7 @@ build_task:
   <<: *CLEANUP_GRADLE_CACHE_SCRIPT
 
 macos_arm64_task:
-#  only_if: $CIRRUS_BRANCH == "master" || $CIRRUS_BRANCH == "dogfood-on-peach" || $CIRRUS_BRANCH =~ "branch-.*"
+  skip: $CIRRUS_BRANCH != "master" && $CIRRUS_BRANCH != "dogfood-on-peach" && $CIRRUS_BRANCH !=~ "branch-.*"
   persistent_worker:
     resources:
       tart-vms: 1

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -108,6 +108,12 @@ macos_arm64_task:
         image: ghcr.io/cirruslabs/macos-sonoma-xcode:latest
         cpu: 4
         memory: 8G
+  env:
+    - HOMEBREW_NO_AUTO_UPDATE: 1
+    - HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
+    - HOMEBREW_NO_INSTALL_UPGRADE: 1
+    - HOMEBREW_NO_INSTALL_CLEANUP: 1
+  <<: *SETUP_GRADLE_CACHE
   install_script:
     - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
     - . $HOME/.cargo/env
@@ -117,11 +123,12 @@ macos_arm64_task:
     - rustup target add x86_64-pc-windows-gnu x86_64-unknown-linux-musl x86_64-unknown-linux-gnu x86_64-apple-darwin
     - rustup component add clippy
   build_script:
-    - source cirrus-env BUILD-PRIVATE
-    - source .cirrus/use-gradle-wrapper.sh
+    - echo "org.gradle.daemon=false" >> "gradle.properties"
+    - echo "org.gradle.vfs.watch=false" >> "gradle.properties"
     - ./gradlew build --info --stacktrace
   plugin_artifacts:
     path: "sonar-rust-plugin/build/libs/**"
+  <<: *CLEANUP_GRADLE_CACHE_SCRIPT
 
 e2e_task:
   depends_on:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -119,7 +119,7 @@ macos_arm64_task:
     - source cirrus-env BUILD-PRIVATE
     - source .cirrus/use-gradle-wrapper.sh
     - ./gradlew build --info --stacktrace
-  build_artifacts:
+  plugin_artifacts:
     path: "sonar-rust-plugin/build/libs/**"
 
 e2e_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -113,7 +113,10 @@ macos_arm64_task:
     - HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
     - HOMEBREW_NO_INSTALL_UPGRADE: 1
     - HOMEBREW_NO_INSTALL_CLEANUP: 1
-#  <<: *SETUP_GRADLE_CACHE
+  gradle_cache:
+    folder: ".gradle"
+  read_brew_script:
+    - brew --cache
   install_script:
     - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
     - . $HOME/.cargo/env
@@ -125,10 +128,10 @@ macos_arm64_task:
   build_script:
     - echo "org.gradle.daemon=false" >> "gradle.properties"
     - echo "org.gradle.vfs.watch=false" >> "gradle.properties"
+    - . $HOME/.cargo/env
     - ./gradlew build --info --stacktrace
   plugin_artifacts:
     path: "sonar-rust-plugin/build/libs/**"
-#  <<: *CLEANUP_GRADLE_CACHE_SCRIPT
 
 e2e_task:
   depends_on:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -35,7 +35,7 @@ cleanup_gradle_cache_script_template: &CLEANUP_GRADLE_CACHE_SCRIPT
     rm -rf "${GRADLE_USER_HOME}"/caches/journal-*
     rm -rf "${GRADLE_USER_HOME}"/workers
     rm -rf "${GRADLE_USER_HOME}"/.tmp
-    /usr/bin/find "${GRADLE_USER_HOME}"/caches/ -name "*.lock" -type f -delete
+    /usr/bin/find "${GRADLE_USER_HOME}"/caches/ -name "*.lock" -type f -delete || true
 
 orchestrator_cache_preparation_definition: &ORCHESTRATOR_CACHE
   set_orchestrator_home_script: |
@@ -113,7 +113,7 @@ macos_arm64_task:
     - HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
     - HOMEBREW_NO_INSTALL_UPGRADE: 1
     - HOMEBREW_NO_INSTALL_CLEANUP: 1
-  <<: *SETUP_GRADLE_CACHE
+#  <<: *SETUP_GRADLE_CACHE
   install_script:
     - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
     - . $HOME/.cargo/env
@@ -128,7 +128,7 @@ macos_arm64_task:
     - ./gradlew build --info --stacktrace
   plugin_artifacts:
     path: "sonar-rust-plugin/build/libs/**"
-  <<: *CLEANUP_GRADLE_CACHE_SCRIPT
+#  <<: *CLEANUP_GRADLE_CACHE_SCRIPT
 
 e2e_task:
   depends_on:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -110,6 +110,7 @@ macos_arm64_task:
         memory: 8G
   install_script:
     - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    - . $HOME/.cargo/env
     - brew install SergioBenitez/osxct/x86_64-unknown-linux-gnu
     - brew install filosottile/musl-cross/musl-cross
     - brew install mingw-w64

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -96,6 +96,32 @@ build_task:
     - source regular_gradle_build_deploy_analyze --info --stacktrace
   <<: *CLEANUP_GRADLE_CACHE_SCRIPT
 
+macos_arm64_task:
+#  only_if: $CIRRUS_BRANCH == "master" || $CIRRUS_BRANCH == "dogfood-on-peach" || $CIRRUS_BRANCH =~ "branch-.*"
+  persistent_worker:
+    resources:
+      tart-vms: 1
+    labels:
+      envname: prod
+    isolation:
+      tart:
+        image: ghcr.io/cirruslabs/macos-sonoma-xcode:latest
+        cpu: 4
+        memory: 8G
+  install_script:
+    - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+    - brew install SergioBenitez/osxct/x86_64-unknown-linux-gnu
+    - brew install filosottile/musl-cross/musl-cross
+    - brew install mingw-w64
+    - rustup target add x86_64-pc-windows-gnu x86_64-unknown-linux-musl x86_64-unknown-linux-gnu x86_64-apple-darwin
+    - rustup component add clippy
+  build_script:
+    - source cirrus-env BUILD-PRIVATE
+    - source .cirrus/use-gradle-wrapper.sh
+    - ./gradlew build --info --stacktrace
+  build_artifacts:
+    path: "sonar-rust-plugin/build/libs/**"
+
 e2e_task:
   depends_on:
     - build

--- a/analyzer/build.gradle.kts
+++ b/analyzer/build.gradle.kts
@@ -39,6 +39,7 @@ val compileRustLinuxMusl = createCompileRustTask(
 )
 val compileRustWin = createCompileRustTask("x86_64-pc-windows-gnu", "Win")
 val compileRustDarwin = createCompileRustTask("aarch64-apple-darwin", "Darwin")
+val compileRustDarwinX86 = createCompileRustTask("x86_64-apple-darwin", "DarwinX86")
 
 
 task<Exec>("testRust") {

--- a/sonar-rust-plugin/build.gradle.kts
+++ b/sonar-rust-plugin/build.gradle.kts
@@ -108,7 +108,7 @@ tasks.register<Copy>("copyRustOutputs") {
   from(compileRustWin.outputs.files) {
     into("win-x64")
   }
-  from(compileRustDarwin.outputs.files) {
+  from("${project(":analyzer").layout.buildDirectory}/aarch64-apple-darwin/release/analyzer") {
     into("darwin-arm64")
   }
   into("${layout.buildDirectory.get()}/resources/main/analyzer")

--- a/sonar-rust-plugin/build.gradle.kts
+++ b/sonar-rust-plugin/build.gradle.kts
@@ -94,10 +94,11 @@ tasks.register<Copy>("copyRustOutputs") {
   val compileRustLinuxMusl = project(":analyzer").tasks.named("compileRustLinuxMusl").get()
   val compileRustWin = project(":analyzer").tasks.named("compileRustWin").get()
   val compileRustDarwin = project(":analyzer").tasks.named("compileRustDarwin").get()
+  val compileRustDarwinX86 = project(":analyzer").tasks.named("compileRustDarwinX86").get()
 
   dependsOn(compileRustLinux, compileRustLinuxMusl, compileRustWin)
   if (OperatingSystem.current().isMacOsX) {
-    dependsOn(compileRustDarwin)
+    dependsOn(compileRustDarwin, compileRustDarwinX86)
   }
   from(compileRustLinux.outputs.files) {
     into("linux-x64")
@@ -111,6 +112,9 @@ tasks.register<Copy>("copyRustOutputs") {
   // we hardcode the path to the binary because on CI binary is downloaded from another task
   from("${project(":analyzer").layout.projectDirectory}/target/aarch64-apple-darwin/release/analyzer") {
     into("darwin-arm64")
+  }
+  from("${project(":analyzer").layout.projectDirectory}/target/x86_64-apple-darwin/release/analyzer") {
+    into("darwin-x86_64")
   }
   into("${layout.buildDirectory.get()}/resources/main/analyzer")
 }

--- a/sonar-rust-plugin/build.gradle.kts
+++ b/sonar-rust-plugin/build.gradle.kts
@@ -108,7 +108,8 @@ tasks.register<Copy>("copyRustOutputs") {
   from(compileRustWin.outputs.files) {
     into("win-x64")
   }
-  from("${project(":analyzer").layout.buildDirectory.get()}/aarch64-apple-darwin/release/analyzer") {
+  // we hardcode the path to the binary because on CI binary is downloaded from another task
+  from("analyzer/target/aarch64-apple-darwin/release/analyzer") {
     into("darwin-arm64")
   }
   into("${layout.buildDirectory.get()}/resources/main/analyzer")

--- a/sonar-rust-plugin/build.gradle.kts
+++ b/sonar-rust-plugin/build.gradle.kts
@@ -108,7 +108,7 @@ tasks.register<Copy>("copyRustOutputs") {
   from(compileRustWin.outputs.files) {
     into("win-x64")
   }
-  from("${project(":analyzer").layout.buildDirectory}/aarch64-apple-darwin/release/analyzer") {
+  from("${project(":analyzer").layout.buildDirectory.get()}/aarch64-apple-darwin/release/analyzer") {
     into("darwin-arm64")
   }
   into("${layout.buildDirectory.get()}/resources/main/analyzer")

--- a/sonar-rust-plugin/build.gradle.kts
+++ b/sonar-rust-plugin/build.gradle.kts
@@ -109,7 +109,7 @@ tasks.register<Copy>("copyRustOutputs") {
     into("win-x64")
   }
   // we hardcode the path to the binary because on CI binary is downloaded from another task
-  from("analyzer/target/aarch64-apple-darwin/release/analyzer") {
+  from("${project(":analyzer").layout.projectDirectory}/target/aarch64-apple-darwin/release/analyzer") {
     into("darwin-arm64")
   }
   into("${layout.buildDirectory.get()}/resources/main/analyzer")

--- a/sonar-rust-plugin/build.gradle.kts
+++ b/sonar-rust-plugin/build.gradle.kts
@@ -108,10 +108,8 @@ tasks.register<Copy>("copyRustOutputs") {
   from(compileRustWin.outputs.files) {
     into("win-x64")
   }
-  if (OperatingSystem.current().isMacOsX) {
-    from(compileRustDarwin.outputs.files) {
-      into("darwin-arm64")
-    }
+  from(compileRustDarwin.outputs.files) {
+    into("darwin-arm64")
   }
   into("${layout.buildDirectory.get()}/resources/main/analyzer")
 }

--- a/sonar-rust-plugin/src/main/java/com/sonarsource/rust/plugin/AnalyzerFactory.java
+++ b/sonar-rust-plugin/src/main/java/com/sonarsource/rust/plugin/AnalyzerFactory.java
@@ -55,6 +55,7 @@ public class AnalyzerFactory {
       case LINUX_X64 -> "/analyzer/linux-x64/analyzer";
       case LINUX_X64_MUSL -> "/analyzer/linux-x64-musl/analyzer";
       case DARWIN_ARM64 -> "/analyzer/darwin-arm64/analyzer";
+      case DARWIN_X86_64 -> "/analyzer/darwin-x86_64/analyzer";
       default -> throw new IllegalStateException("Unsupported platform");
     };
   }

--- a/sonar-rust-plugin/src/main/java/com/sonarsource/rust/plugin/Platform.java
+++ b/sonar-rust-plugin/src/main/java/com/sonarsource/rust/plugin/Platform.java
@@ -14,6 +14,7 @@ enum Platform {
   LINUX_X64,
   LINUX_X64_MUSL,
   DARWIN_ARM64,
+  DARWIN_X86_64,
   UNSUPPORTED;
 
 
@@ -28,8 +29,8 @@ enum Platform {
       return WIN_X64;
     } else if (lowerCaseOsName.contains("linux") && isX64()) {
       return isAlpine() ? LINUX_X64_MUSL : LINUX_X64;
-    } else if (lowerCaseOsName.contains("mac os") && isARM64()) {
-      return DARWIN_ARM64;
+    } else if (lowerCaseOsName.contains("mac os")) {
+      return isARM64() ? DARWIN_ARM64 : DARWIN_X86_64;
     }
     return UNSUPPORTED;
   }


### PR DESCRIPTION
Mac OS workers are scarce resource see https://xtranet-sonarsource.atlassian.net/wiki/spaces/Platform/pages/3448012818/MacOS+Persistent+Workers+-+Cirrus+CI

We execute MacOS task only on `master` branch, when building the branch or PR we will skip it and MacOS binary will not be part of the build. 

For review you can check that older artifact included also MacOS binaries 
https://repox.jfrog.io/ui/repos/tree/General/sonarsource-private-qa/com/sonarsource/rust/sonar-rust-plugin/0.1.0.436/sonar-rust-plugin-0.1.0.436.jar?clearFilter=true

and we should check the master once merged