### PR TITLE
Change the log level to DEBUG when no Cargo manifest paths were provided

### DIFF
--- a/sonar-rust-plugin/src/main/java/com/sonarsource/rust/cargo/CargoManifestProvider.java
+++ b/sonar-rust-plugin/src/main/java/com/sonarsource/rust/cargo/CargoManifestProvider.java
@@ -37,7 +37,7 @@ public class CargoManifestProvider {
 
       var manifestPatterns = context.config().getStringArray(CARGO_MANIFEST_PATHS);
       if (manifestPatterns.length == 0) {
-        LOG.warn("No Cargo manifest paths were provided");
+        LOG.debug("No Cargo manifest paths were provided");
         return List.of();
       }
 


### PR DESCRIPTION
While reviewing the analysis logs of the projects we analyze on Peach, I noticed that [one log](https://cirrus-ci.com/task/6440992477282304?logs=analyze#L124) was consistently printed as a warning, indicating that no Cargo manifest paths were provided:

```
09:15:46.084 INFO  Sensor Clippy [rust]
09:15:46.085 WARN  No Cargo manifest paths were provided
09:16:03.450 INFO  Sensor Clippy [rust] (done) | time=17366ms
```

Although this log is informative, it doesn't warrant a warning level since not explicitly providing manifest paths is not a mistake from the user's perspective. The expected default use case is to have a manifest file located at the project root. 

As a consequence, I decided to change the log level to debug.