### PR TITLE
SKUNK-49 S2260 Should not produce malformed issue locations

### DIFF
--- a/analyzer/src/analyze.rs
+++ b/analyzer/src/analyze.rs
@@ -28,7 +28,7 @@ pub fn analyze(source_code: &str) -> Result<Output, AnalyzerError> {
         highlight_tokens: highlight(&tree, source_code)?,
         metrics: calculate_metrics(&tree, source_code)?,
         cpd_tokens: calculate_cpd_tokens(&tree, source_code),
-        issues: find_issues(&tree, source_code),
+        issues: find_issues(&tree, source_code)?,
     })
 }
 

--- a/analyzer/src/issue.rs
+++ b/analyzer/src/issue.rs
@@ -4,7 +4,7 @@
  * mailto:info AT sonarsource DOT com
  */
 use crate::rules::rule::all_rules;
-use crate::tree::SonarLocation;
+use crate::tree::{AnalyzerError, SonarLocation};
 use tree_sitter::Tree;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
@@ -14,10 +14,10 @@ pub struct Issue {
     pub location: SonarLocation,
 }
 
-pub fn find_issues(tree: &Tree, source_code: &str) -> Vec<Issue> {
+pub fn find_issues(tree: &Tree, source_code: &str) -> Result<Vec<Issue>, AnalyzerError> {
     let mut issues = Vec::new();
     for rule in all_rules() {
-        issues.extend(rule.check(tree, source_code));
+        issues.extend(rule.check(tree, source_code)?);
     }
-    issues
+    Ok(issues)
 }

--- a/analyzer/src/rules/parsing_error_check.rs
+++ b/analyzer/src/rules/parsing_error_check.rs
@@ -84,8 +84,8 @@ impl NodeVisitor for RuleVisitor<'_> {
 
             // The location of the missing node is the location of the token that should have been there, which means that it might not
             // even exist in the original source code.
-            // In order to avoid reporting on non-existant locations, we use the location of the closest non-error ancestor node.
-            let parent = match non_error_parent(node) {
+            // In order to avoid reporting on non-existant locations, we use the location of the parent node.
+            let parent = match node.parent() {
                 Some(parent) => parent,
                 None => {
                     self.error = Some(AnalyzerError::FileError(
@@ -101,17 +101,6 @@ impl NodeVisitor for RuleVisitor<'_> {
             self.new_issue(message, location);
         }
     }
-}
-
-fn non_error_parent(node: Node<'_>) -> Option<Node<'_>> {
-    let mut parent = node.parent();
-    while let Some(p) = parent {
-        if !p.is_error() && !p.is_missing() {
-            return Some(p);
-        }
-        parent = p.parent();
-    }
-    None
 }
 
 #[cfg(test)]

--- a/analyzer/src/rules/rule.rs
+++ b/analyzer/src/rules/rule.rs
@@ -4,11 +4,11 @@
  * mailto:info AT sonarsource DOT com
  */
 
-use crate::{issue::Issue, rules::parsing_error_check::ParsingErrorCheck};
+use crate::{issue::Issue, rules::parsing_error_check::ParsingErrorCheck, tree::AnalyzerError};
 use tree_sitter::Tree;
 
 pub trait Rule {
-    fn check(&self, tree: &Tree, source_code: &str) -> Vec<Issue>;
+    fn check(&self, tree: &Tree, source_code: &str) -> Result<Vec<Issue>, AnalyzerError>;
 }
 
 pub fn all_rules() -> Vec<Box<dyn Rule>> {

--- a/sonar-rust-plugin/src/test/java/com/sonarsource/rust/plugin/AnalyzerTest.java
+++ b/sonar-rust-plugin/src/test/java/com/sonarsource/rust/plugin/AnalyzerTest.java
@@ -100,7 +100,7 @@ class AnalyzerTest {
         """);
 
       assertThat(result.issues()).containsExactly(
-        new Analyzer.Issue("S2260", "A syntax error occurred during parsing: missing \";\".", 2, 12, 2, 13));
+        new Analyzer.Issue("S2260", "A syntax error occurred during parsing: missing \";\".", 2, 2, 2, 12));
     }
   }
 }

--- a/sonar-rust-plugin/src/test/java/com/sonarsource/rust/plugin/AnalyzerTest.java
+++ b/sonar-rust-plugin/src/test/java/com/sonarsource/rust/plugin/AnalyzerTest.java
@@ -100,7 +100,7 @@ class AnalyzerTest {
         """);
 
       assertThat(result.issues()).containsExactly(
-        new Analyzer.Issue("S2260", "A syntax error occurred during parsing: missing \";\".", 2, 2, 2, 12));
+        new Analyzer.Issue("S2260", "A syntax error occurred during parsing: missing \";\".", 2, 10, 2, 12));
     }
   }
 }

--- a/sonar-rust-plugin/src/test/java/com/sonarsource/rust/plugin/RustSensorTest.java
+++ b/sonar-rust-plugin/src/test/java/com/sonarsource/rust/plugin/RustSensorTest.java
@@ -93,6 +93,24 @@ class RustSensorTest {
     assertThat(issue.primaryLocation().textRange().start().line()).isEqualTo(1);
   }
 
+  @Test
+  void analyze_syntax_errors_location_at_end_of_line() {
+    var sensor = sensor();
+    context.fileSystem().add(inputFile("main.rs", """
+fn main() {
+  let x = 42
+}"""));
+
+    sensor.execute(context);
+
+    assertThat(context.allIssues()).hasSize(1);
+
+    var issue = context.allIssues().iterator().next();
+    assertThat(issue.ruleKey().rule()).isEqualTo("S2260");
+    assertThat(issue.primaryLocation().message()).isEqualTo("A syntax error occurred during parsing: missing \";\".");
+    assertThat(issue.primaryLocation().textRange().start().line()).isEqualTo(2);
+  }
+
   private InputFile inputFile(String relativePath, String content) {
     return new TestInputFileBuilder(PROJECT_KEY, relativePath)
       .setModuleBaseDir(baseDir.toPath())


### PR DESCRIPTION
The location of the "missing" node is the location where the missing token should be inserted. This means that the location might not even exist in the source file, so this PR changes the location to use a sibling/parent node as the location instead.