### PR TITLE
SKUNK-61 Fix intermittent failure when detecting Clippy version

### DIFF
--- a/sonar-rust-plugin/src/main/java/com/sonarsource/rust/clippy/ClippyPrerequisite.java
+++ b/sonar-rust-plugin/src/main/java/com/sonarsource/rust/clippy/ClippyPrerequisite.java
@@ -30,13 +30,13 @@ public class ClippyPrerequisite {
 
   public void check(Path workDir) {
     checkVersion(List.of("cargo", "--version"), "Cargo", workDir);
-    checkVersion(List.of("cargo", "clippy", "--version"), "Clippy", workDir);
+    checkVersion(List.of("cargo", "clippy", "--version2"), "Clippy", workDir);
   }
 
   private void checkVersion(List<String> command, String prerequisite, Path workDir) {
     LOG.debug("Checking {} version", prerequisite);
     try {
-      processWrapper.start(command, workDir, LOG::debug, LOG::warn);
+      processWrapper.start(command, workDir, null, LOG::warn);
       try (var reader = new BufferedReader(new InputStreamReader(processWrapper.getInputStream()))) {
         var version = reader.readLine();
         LOG.debug("{} version: {}", prerequisite, version);

--- a/sonar-rust-plugin/src/main/java/com/sonarsource/rust/clippy/ClippyPrerequisite.java
+++ b/sonar-rust-plugin/src/main/java/com/sonarsource/rust/clippy/ClippyPrerequisite.java
@@ -30,7 +30,7 @@ public class ClippyPrerequisite {
 
   public void check(Path workDir) {
     checkVersion(List.of("cargo", "--version"), "Cargo", workDir);
-    checkVersion(List.of("cargo", "clippy", "--version2"), "Clippy", workDir);
+    checkVersion(List.of("cargo", "clippy", "--version"), "Clippy", workDir);
   }
 
   private void checkVersion(List<String> command, String prerequisite, Path workDir) {

--- a/sonar-rust-plugin/src/test/java/com/sonarsource/rust/clippy/ClippyPrerequisiteTest.java
+++ b/sonar-rust-plugin/src/test/java/com/sonarsource/rust/clippy/ClippyPrerequisiteTest.java
@@ -5,15 +5,6 @@
  */
 package com.sonarsource.rust.clippy;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import com.sonarsource.rust.common.ProcessWrapper;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -23,6 +14,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.event.Level;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class ClippyPrerequisiteTest {
 


### PR DESCRIPTION
The detection logic may fail intermittently, as the stream might be consumed by the set consumer. This PR removes the consumer, so there should be no race condition.
