### PR TITLE
SKUNK-70 Fix SQ Cloud bootstrapping in Pico

### DIFF
--- a/sonar-rust-plugin/src/main/java/com/sonarsource/rust/plugin/AnalysisWarningsWrapper.java
+++ b/sonar-rust-plugin/src/main/java/com/sonarsource/rust/plugin/AnalysisWarningsWrapper.java
@@ -26,7 +26,7 @@ import org.sonarsource.api.sonarlint.SonarLintSide;
  */
 @ScannerSide
 @SonarLintSide
-public class AnalysisWarningsWrapper implements AnalysisWarnings {
+public class AnalysisWarningsWrapper {
 
   private final AnalysisWarnings warnings;
 
@@ -38,7 +38,6 @@ public class AnalysisWarningsWrapper implements AnalysisWarnings {
     this.warnings = warnings;
   }
 
-  @Override
   public void addUnique(String text) {
     if (warnings != null) {
       warnings.addUnique(text);


### PR DESCRIPTION
We can't provide another implementation of `AnalysisWarnings` because then component resolution is ambigious in Pico container.

```
Caused by: java.lang.IllegalStateException: Unable to load component class org.sonar.scanner.scan.ProjectServerSettings
	at org.sonar.core.platform.ComponentContainer$ExtendedDefaultPicoContainer.getComponent(ComponentContainer.java:52)
	at org.picocontainer.DefaultPicoContainer.getComponent(DefaultPicoContainer.java:632)
	at org.picocontainer.parameters.BasicComponentParameter$1.resolveInstance(BasicComponentParameter.java:118)
	at org.picocontainer.parameters.ComponentParameter$1.resolveInstance(ComponentParameter.java:136)
	at org.picocontainer.injectors.SingleMemberInjector.getParameter(SingleMemberInjector.java:78)
	at org.picocontainer.injectors.ConstructorInjector$CtorAndAdapters.getParameterArguments(ConstructorInjector.java:309)
	at org.picocontainer.injectors.ConstructorInjector$1.run(ConstructorInjector.java:335)
	at org.picocontainer.injectors.AbstractInjector$ThreadLocalCyclicDependencyGuard.observe(AbstractInjector.java:270)
	at org.picocontainer.injectors.ConstructorInjector.getComponentInstance(ConstructorInjector.java:364)
	at org.picocontainer.injectors.AbstractInjectionFactory$LifecycleAdapter.getComponentInstance(AbstractInjectionFactory.java:56)
	at org.picocontainer.behaviors.AbstractBehavior.getComponentInstance(AbstractBehavior.java:64)
	at org.picocontainer.behaviors.Stored.getComponentInstance(Stored.java:91)
	at org.picocontainer.DefaultPicoContainer.getInstance(DefaultPicoContainer.java:699)
	at org.picocontainer.DefaultPicoContainer.getComponent(DefaultPicoContainer.java:647)
	at org.sonar.core.platform.ComponentContainer$ExtendedDefaultPicoContainer.getComponent(ComponentContainer.java:50)
	... 22 more
Caused by: org.picocontainer.injectors.AbstractInjector$AmbiguousComponentResolutionException: org.sonar.scanner.scan.ProjectServerSettingsProvider@782bf610 needs a 'org.sonar.api.notifications.AnalysisWarnings' injected via 'public org.sonar.scanner.scan.ProjectServerSettings org.sonar.scanner.scan.ProjectServerSettingsProvider.provide(org.sonar.scanner.repository.settings.ProjectSettingsLoader,org.sonar.api.notifications.AnalysisWarnings)', but there are too many choices to inject. These:[ConstructorInjector-class com.sonarsource.rust.plugin.AnalysisWarningsWrapper, ConstructorInjector-class org.sonar.scanner.notifications.DefaultAnalysisWarnings], refer http://picocontainer.org/ambiguous-injectable-help.html
	at org.picocontainer.parameters.BasicComponentParameter.tooManyMatchingAdaptersFound(BasicComponentParameter.java:260)
	at org.picocontainer.parameters.BasicComponentParameter.resolveAdapter(BasicComponentParameter.java:222)
	at org.picocontainer.parameters.BasicComponentParameter.resolve(BasicComponentParameter.java:100)
	at org.picocontainer.parameters.ComponentParameter.access$001(ComponentParameter.java:39)

```