### PR TITLE
Use a Rust-specific internal fail-fast property

### DIFF
--- a/sonar-rust-plugin/src/main/java/com/sonarsource/rust/plugin/RustPlugin.java
+++ b/sonar-rust-plugin/src/main/java/com/sonarsource/rust/plugin/RustPlugin.java
@@ -28,7 +28,7 @@ import org.sonar.api.config.PropertyDefinition.ConfigScope;
 
 public class RustPlugin implements Plugin {
 
-  public static final String FAIL_FAST_PROPERTY = "sonar.internal.analysis.failFast";
+  public static final String FAIL_FAST_PROPERTY = "sonar.internal.analysis.rust.failFast";
 
   @Override
   public void define(Context context) {

--- a/sonar-rust-plugin/src/test/java/com/sonarsource/rust/clippy/ClippySensorTest.java
+++ b/sonar-rust-plugin/src/test/java/com/sonarsource/rust/clippy/ClippySensorTest.java
@@ -125,7 +125,7 @@ class ClippySensorTest {
     doThrow(new IllegalStateException("error")).when(clippyRunner).run(any(), any(), any());
     var warnings = new TestAnalysisWarnigs();
     var sensor = new ClippySensor(clippyPrerequisite, clippyRunner, new AnalysisWarningsWrapper(warnings));
-    context.settings().setProperty("sonar.internal.analysis.failFast", "true");
+    context.settings().setProperty("sonar.internal.analysis.rust.failFast", "true");
     assertThatThrownBy(() -> sensor.execute(context)).isInstanceOf(IllegalStateException.class);
 
     assertThat(logTester.logs()).contains("Failed to run Clippy");

--- a/sonar-rust-plugin/src/test/java/com/sonarsource/rust/plugin/RustSensorTest.java
+++ b/sonar-rust-plugin/src/test/java/com/sonarsource/rust/plugin/RustSensorTest.java
@@ -185,7 +185,7 @@ fn foo(c1: bool) {
       }
     }, new AnalysisWarningsWrapper(warnings));
 
-    context.settings().setProperty("sonar.internal.analysis.failFast", "true");
+    context.settings().setProperty("sonar.internal.analysis.rust.failFast", "true");
 
     assertThatThrownBy(() -> sensor.execute(context))
       .isInstanceOf(IllegalStateException.class)


### PR DESCRIPTION
This PR introduces a Rust-specific fail-fast flag instead of our usual `sonar.internal.analysis.failFast`. Many of other languages' test projects may contain a few example Rust files and we should not crash the whole analysis for them in case Cargo is not available.