### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,3 +14,7 @@ jobs:
       id-token: write
       contents: write
     uses: SonarSource/gh-action_release/.github/workflows/main.yaml@34d8b20d125bfd58d124e84b007d3a18e61c358a # 5.10.4
+  with:
+    publishToBinaries: true
+    mavenCentralSync: true
+    slackChannel: squad-rust


### PR DESCRIPTION
We were missing sync with maven central, which is needed for open source plugins