### PR TITLE
Build javadoc and sources jar

### DIFF
--- a/sonar-rust-plugin/build.gradle.kts
+++ b/sonar-rust-plugin/build.gradle.kts
@@ -47,6 +47,8 @@ java {
   toolchain {
     languageVersion = JavaLanguageVersion.of(17)
   }
+  withSourcesJar()
+  withJavadocJar()
 }
 
 tasks.jacocoTestReport {

--- a/sonar-rust-plugin/build.gradle.kts
+++ b/sonar-rust-plugin/build.gradle.kts
@@ -196,6 +196,8 @@ publishing {
       artifact(tasks.shadowJar) {
         classifier = null
       }
+      artifact(tasks.named("javadocJar"))
+      artifact(tasks.named("sourcesJar"))
     }
   }
 }

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/common/FileLocator.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/common/FileLocator.java
@@ -26,7 +26,7 @@ import org.sonar.api.utils.PathUtils;
  * It is responsible for locating files based on their paths using a reverse path tree to index and retrieve files efficiently.
  * The logic for this class was adapted from the JavaScript analyzer, which uses similar logic for parsing LCOV files.
  *
- * @see https://github.com/SonarSource/SonarJS/blob/master/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/FileLocator.java
+ * @see <a href="https://github.com/SonarSource/SonarJS/blob/master/sonar-plugin/sonar-javascript-plugin/src/main/java/org/sonar/plugins/javascript/lcov/FileLocator.java">SonarJS FileLocator</a>
  */
 public class FileLocator {
 


### PR DESCRIPTION
Artifacts are now deployed, as you can see in the build log https://cirrus-ci.com/task/6217259745542144?logs=build#L4298 

```
[pool-1-thread-1] Deploying artifact: HIDDEN-BY-CIRRUS-CI/sonarsource-public-qa/org/sonarsource/rust/sonar-rust-plugin/1.0.1.729/sonar-rust-plugin-1.0.1.729-javadoc.jar
[pool-1-thread-1] Deploying artifact: HIDDEN-BY-CIRRUS-CI/sonarsource-public-qa/org/sonarsource/rust/sonar-rust-plugin/1.0.1.729/sonar-rust-plugin-1.0.1.729-javadoc.jar.asc
[pool-1-thread-1] Deploying artifact: HIDDEN-BY-CIRRUS-CI/sonarsource-public-qa/org/sonarsource/rust/sonar-rust-plugin/1.0.1.729/sonar-rust-plugin-1.0.1.729-sources.jar
[pool-1-thread-1] Deploying artifact: HIDDEN-BY-CIRRUS-CI/sonarsource-public-qa/org/sonarsource/rust/sonar-rust-plugin/1.0.1.729/sonar-rust-plugin-1.0.1.729-sources.jar.asc
[pool-1-thread-1] Deploying artifact: HIDDEN-BY-CIRRUS-CI/sonarsource-public-qa/org/sonarsource/rust/sonar-rust-plugin/1.0.1.729/sonar-rust-plugin-1.0.1.729.jar
[pool-1-thread-1] Deploying artifact: HIDDEN-BY-CIRRUS-CI/sonarsource-public-qa/org/sonarsource/rust/sonar-rust-plugin/1.0.1.729/sonar-rust-plugin-1.0.1.729.jar.asc
```
