### PR TITLE
RUST-18 Use "sonar.scanner.skipJreProvisioning" in integration tests

### DIFF
--- a/e2e/src/test/java/org/sonarsource/rust/e2e/ClippyReportTest.java
+++ b/e2e/src/test/java/org/sonarsource/rust/e2e/ClippyReportTest.java
@@ -8,7 +8,6 @@ package org.sonarsource.rust.e2e;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
-import com.sonar.orchestrator.build.SonarScanner;
 import com.sonar.orchestrator.container.Server;
 import com.sonar.orchestrator.junit5.OrchestratorExtension;
 import java.nio.file.Files;
@@ -44,7 +43,7 @@ class ClippyReportTest {
     Process process = processBuilder.start();
     process.waitFor();
 
-    var scanner = SonarScanner.create()
+    var scanner = OrchestratorHelper.createSonarScanner()
       .setProjectKey(projectKey)
       .setProjectName(projectName)
       .setProjectDir(projectDir)

--- a/e2e/src/test/java/org/sonarsource/rust/e2e/ClippyRunnerTest.java
+++ b/e2e/src/test/java/org/sonarsource/rust/e2e/ClippyRunnerTest.java
@@ -8,7 +8,6 @@ package org.sonarsource.rust.e2e;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
-import com.sonar.orchestrator.build.SonarScanner;
 import com.sonar.orchestrator.container.Server;
 import com.sonar.orchestrator.junit5.OrchestratorExtension;
 import java.nio.file.Paths;
@@ -31,7 +30,7 @@ class ClippyRunnerTest {
     var projectName = "Clippy";
     var projectDir = Paths.get(getClass().getClassLoader().getResource("projects/runner").toURI()).toFile();
 
-    var scanner = SonarScanner.create()
+    var scanner = OrchestratorHelper.createSonarScanner()
       .setProjectKey(projectKey)
       .setProjectName(projectName)
       .setProjectDir(projectDir)

--- a/e2e/src/test/java/org/sonarsource/rust/e2e/CoverageTest.java
+++ b/e2e/src/test/java/org/sonarsource/rust/e2e/CoverageTest.java
@@ -7,7 +7,6 @@ package org.sonarsource.rust.e2e;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.sonar.orchestrator.build.SonarScanner;
 import com.sonar.orchestrator.container.Server;
 import com.sonar.orchestrator.junit5.OrchestratorExtension;
 import java.nio.file.Paths;
@@ -30,7 +29,7 @@ class CoverageTest {
     var projectName = "Coverage";
     var projectDir = Paths.get(getClass().getClassLoader().getResource("projects/coverage").toURI()).toFile();
 
-    var scanner = SonarScanner.create()
+    var scanner = OrchestratorHelper.createSonarScanner()
       .setProjectKey(projectKey)
       .setProjectName(projectName)
       .setProjectDir(projectDir)
@@ -69,7 +68,7 @@ class CoverageTest {
     var projectName = "Coverage";
     var projectDir = Paths.get(getClass().getClassLoader().getResource("projects/coverage").toURI()).toFile();
 
-    var scanner = SonarScanner.create()
+    var scanner = OrchestratorHelper.createSonarScanner()
       .setProjectKey(projectKey)
       .setProjectName(projectName)
       .setProjectDir(projectDir)

--- a/e2e/src/test/java/org/sonarsource/rust/e2e/DuplicationTest.java
+++ b/e2e/src/test/java/org/sonarsource/rust/e2e/DuplicationTest.java
@@ -7,7 +7,6 @@ package org.sonarsource.rust.e2e;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.sonar.orchestrator.build.SonarScanner;
 import com.sonar.orchestrator.container.Server;
 import com.sonar.orchestrator.junit5.OrchestratorExtension;
 import java.nio.file.Paths;
@@ -30,7 +29,7 @@ class DuplicationTest {
     var projectName = "Code Duplication";
     var projectDir = Paths.get(getClass().getClassLoader().getResource("projects/duplication").toURI()).toFile();
 
-    var scanner = SonarScanner.create()
+    var scanner = OrchestratorHelper.createSonarScanner()
       .setProjectKey(projectKey)
       .setProjectName(projectName)
       .setProjectDir(projectDir)

--- a/e2e/src/test/java/org/sonarsource/rust/e2e/MetricsTest.java
+++ b/e2e/src/test/java/org/sonarsource/rust/e2e/MetricsTest.java
@@ -7,7 +7,6 @@ package org.sonarsource.rust.e2e;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.sonar.orchestrator.build.SonarScanner;
 import com.sonar.orchestrator.container.Server;
 import com.sonar.orchestrator.junit5.OrchestratorExtension;
 import java.nio.file.Paths;
@@ -30,7 +29,7 @@ class MetricsTest {
     var projectName = "Metrics";
     var projectDir = Paths.get(getClass().getClassLoader().getResource("projects/metrics").toURI()).toFile();
 
-    var scanner = SonarScanner.create()
+    var scanner = OrchestratorHelper.createSonarScanner()
       .setProjectKey(projectKey)
       .setProjectName(projectName)
       .setProjectDir(projectDir)

--- a/e2e/src/test/java/org/sonarsource/rust/e2e/OrchestratorHelper.java
+++ b/e2e/src/test/java/org/sonarsource/rust/e2e/OrchestratorHelper.java
@@ -7,6 +7,7 @@ package org.sonarsource.rust.e2e;
 
 import static org.junit.jupiter.api.extension.ExtensionContext.Namespace.GLOBAL;
 
+import com.sonar.orchestrator.build.SonarScanner;
 import com.sonar.orchestrator.junit5.OrchestratorExtension;
 import com.sonar.orchestrator.locator.FileLocation;
 import com.sonar.orchestrator.locator.Location;
@@ -55,5 +56,10 @@ public class OrchestratorHelper implements BeforeAllCallback,  ExtensionContext.
 
   static OrchestratorExtension orchestrator() {
     return orchestrator;
+  }
+
+  static SonarScanner createSonarScanner() {
+    return SonarScanner.create()
+      .setProperty("sonar.scanner.skipJreProvisioning", "true");
   }
 }

--- a/e2e/src/test/java/org/sonarsource/rust/e2e/ProjectLayoutTest.java
+++ b/e2e/src/test/java/org/sonarsource/rust/e2e/ProjectLayoutTest.java
@@ -8,7 +8,6 @@ package org.sonarsource.rust.e2e;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
-import com.sonar.orchestrator.build.SonarScanner;
 import com.sonar.orchestrator.container.Server;
 import com.sonar.orchestrator.junit5.OrchestratorExtension;
 import java.nio.file.Paths;
@@ -41,7 +40,7 @@ class ProjectLayoutTest {
     var projectName = "Package Layout";
     var projectDir = Paths.get(getClass().getClassLoader().getResource("projects/layouts/package").toURI()).toFile();
 
-    var scanner = SonarScanner.create()
+    var scanner = OrchestratorHelper.createSonarScanner()
       .setProjectKey(projectKey)
       .setProjectName(projectName)
       .setProjectDir(projectDir)
@@ -86,7 +85,7 @@ class ProjectLayoutTest {
     var projectName = "Hybrid Layout";
     var projectDir = Paths.get(getClass().getClassLoader().getResource("projects/layouts/hybrid").toURI()).toFile();
 
-    var scanner = SonarScanner.create()
+    var scanner = OrchestratorHelper.createSonarScanner()
       .setProjectKey(projectKey)
       .setProjectName(projectName)
       .setProjectDir(projectDir)
@@ -134,7 +133,7 @@ class ProjectLayoutTest {
     var projectName = "Monorepo Layout";
     var projectDir = Paths.get(getClass().getClassLoader().getResource("projects/layouts/monorepo").toURI()).toFile();
 
-    var scanner = SonarScanner.create()
+    var scanner = OrchestratorHelper.createSonarScanner()
       .setProjectKey(projectKey)
       .setProjectName(projectName)
       .setProjectDir(projectDir)
@@ -183,7 +182,7 @@ class ProjectLayoutTest {
     var projectName = "Workspace Layout";
     var projectDir = Paths.get(getClass().getClassLoader().getResource("projects/layouts/workspace").toURI()).toFile();
 
-    var scanner = SonarScanner.create()
+    var scanner = OrchestratorHelper.createSonarScanner()
       .setProjectKey(projectKey)
       .setProjectName(projectName)
       .setProjectDir(projectDir)


### PR DESCRIPTION
On ephemeral CI machine this avoids unnecessary downloading and unpacking of JRE from SQ and thus reduces time of execution of the first project analysis in integration tests.

During execution of integration tests we already have suitable JDK.

Testing of JRE provisioning feature should not be the responsibility of analyzers.