### PR TITLE
RUST-104 Update license of newly introduced file

### DIFF
--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/common/StreamConsumerTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/common/StreamConsumerTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025 SonarSource Sàrl
+ * Copyright (C) 2025-2026 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or


### PR DESCRIPTION
A pull request introducing a new file was merged before updating the license headers. Unfortunately, the PR that introduces the license header update was not up-to-date.

This pull request updates the license header of the newly introduced file that was omitted.