### PR TITLE
RUST-102 Prevent analysis crash on malformed Clippy diagnostic location

### DIFF
--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippySensor.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippySensor.java
@@ -109,7 +109,13 @@ public class ClippySensor implements Sensor {
         Telemetry.reportManifestInfo(context, manifestPath);
 
         var workDir = manifestPath.getParent();
-        clippy.run(workDir, lints, diagnostic -> saveIssue(context, diagnostic, workDir), offlineMode);
+        clippy.run(workDir, lints, diagnostic -> {
+          try {
+            saveIssue(context, diagnostic, workDir);
+          } catch (Exception e) {
+            LOG.warn("Failed to save Clippy issue: {}", diagnostic, e);
+          }
+        }, offlineMode);
       }
     } catch (Exception e) {
       LOG.error("Failed to run Clippy", e);


### PR DESCRIPTION
This pull request addresses runtime failures triggered by Clippy diagnostics with location that SonarQube considers malformed (e.g., end lines/columns matching start lines/columns). Previously, encountering such a diagnostic would terminate the entire analysis with a misleading `Failed to run Clippy` error.

This change ensures that:

1. A single malformed issue no longer halts the entire analysis or prevents subsequent issues from being saved.
2. The misleading "Failed to run Clippy" error has been replaced with a specific warning that identifies exactly why an individual issue could not be saved.