### PR TITLE
RUST-106 Upgrade assertj-core to 3.27.7

### DIFF
--- a/e2e/build.gradle.kts
+++ b/e2e/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 val orchestratorVersion = "6.0.1.3892"
 
 dependencies {
-    testImplementation("org.assertj:assertj-core:3.26.0")
+    testImplementation("org.assertj:assertj-core:3.27.7")
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("org.sonarsource.orchestrator:sonar-orchestrator-junit5:$orchestratorVersion")
     testImplementation("org.sonarsource.orchestrator:sonar-orchestrator:$orchestratorVersion")

--- a/sonar-rust-plugin/build.gradle.kts
+++ b/sonar-rust-plugin/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
   testImplementation("org.sonarsource.sonarqube:sonar-plugin-api-impl:$sonarApiImplVersion")
   testImplementation(platform("org.junit:junit-bom:5.12.2"))
   testImplementation("org.junit.jupiter:junit-jupiter")
-  testImplementation("org.assertj:assertj-core:3.27.3")
+  testImplementation("org.assertj:assertj-core:3.27.7")
   testImplementation("org.mockito:mockito-core:5.18.0")
   testImplementation("org.awaitility:awaitility:4.2.0")
   testRuntimeOnly("org.junit.platform:junit-platform-launcher")


### PR DESCRIPTION
This pull request updates the AssertJ testing library version in both the `e2e` and `sonar-rust-plugin` modules to fix a security vulnerability reported by the Next analysis, making the quality gate red.

**Dependency updates:**

* Upgraded `org.assertj:assertj-core` from version `3.26.0` to `3.27.7` in `e2e/build.gradle.kts` to use the latest features and bug fixes.
* Upgraded `org.assertj:assertj-core` from version `3.27.3` to `3.27.7` in `sonar-rust-plugin/build.gradle.kts` for improved consistency and reliability in tests.