### PR TITLE
RUST-108 Set buildSrc root project name

### DIFF
--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -5,3 +5,5 @@ dependencyResolutionManagement {
         }
     }
 }
+
+rootProject.name = "buildSrc"


### PR DESCRIPTION
This pull request fixes the quality gate, in particular this [issue](https://next.sonarqube.com/sonarqube/project/issues?inNewCodePeriod=true&issueStatuses=OPEN%2CCONFIRMED&open=22899938-df3f-4b99-9ea7-f730932111f7&id=SonarSource_sonar-rust).