### PR TITLE
SKUNK-1949 Add rolling orchestrator cache

### DIFF
--- a/.github/actions/orchestrator-cache/action.yml
+++ b/.github/actions/orchestrator-cache/action.yml
@@ -1,0 +1,26 @@
+name: Setup Orchestrator Cache
+description: Setup rolling orchestrator cache with monthly restore keys
+
+inputs:
+  key-prefix:
+    description: Prefix for the cache key
+    required: false
+    default: orchestrator
+
+runs:
+  using: composite
+  steps:
+    - name: Set orchestrator cache variables
+      # We need to specify bash so it works on both Windows and Linux runners.
+      shell: bash
+      run: |
+        echo "ORCHESTRATOR_CACHE_MONTH=$(date +'%Y-%m')" >> "$GITHUB_ENV"
+        echo "ORCHESTRATOR_HOME=${{ github.workspace }}/orchestrator" >> "$GITHUB_ENV"
+        mkdir -p "${{ github.workspace }}/orchestrator"
+
+    - name: Restore and save orchestrator cache
+      uses: SonarSource/gh-action_cache@v1
+      with:
+        path: ${{ env.ORCHESTRATOR_HOME }}
+        key: ${{ inputs.key-prefix }}-${{ env.ORCHESTRATOR_CACHE_MONTH }}-${{ github.run_id }}
+        restore-keys: ${{ inputs.key-prefix }}-${{ env.ORCHESTRATOR_CACHE_MONTH }}-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,10 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - name: Setup orchestrator cache
+        uses: ./.github/actions/orchestrator-cache
+        with:
+          key-prefix: e2e
       - uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
         with:
           version: 2025.7.12
@@ -136,6 +140,10 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - name: Setup orchestrator cache
+        uses: ./.github/actions/orchestrator-cache
+        with:
+          key-prefix: e2e
       - uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
         with:
           version: 2025.7.12
@@ -169,6 +177,10 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - name: Setup orchestrator cache
+        uses: ./.github/actions/orchestrator-cache
+        with:
+          key-prefix: e2e
       - uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
         with:
           version: 2025.7.12

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,10 +65,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      - name: Setup orchestrator cache
-        uses: ./.github/actions/orchestrator-cache
-        with:
-          key-prefix: e2e
       - uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
         with:
           version: 2025.7.12
@@ -140,10 +136,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      - name: Setup orchestrator cache
-        uses: ./.github/actions/orchestrator-cache
-        with:
-          key-prefix: e2e
       - uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
         with:
           version: 2025.7.12
@@ -177,10 +169,6 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      - name: Setup orchestrator cache
-        uses: ./.github/actions/orchestrator-cache
-        with:
-          key-prefix: e2e
       - uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
         with:
           version: 2025.7.12
@@ -229,6 +217,10 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - name: Setup orchestrator cache
+        uses: ./.github/actions/orchestrator-cache
+        with:
+          key-prefix: e2e
       - uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
         with:
           version: 2025.7.12
@@ -255,6 +247,10 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - name: Setup orchestrator cache
+        uses: ./.github/actions/orchestrator-cache
+        with:
+          key-prefix: e2e
       - uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
         with:
           version: 2025.7.12
@@ -295,6 +291,10 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - name: Setup orchestrator cache
+        uses: ./.github/actions/orchestrator-cache
+        with:
+          key-prefix: e2e
       - uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
         with:
           version: 2025.7.12


### PR DESCRIPTION
## Summary
- add a composite GitHub Action to cache the Orchestrator home with a monthly rolling key
- enable that cache in the Linux, Windows, and ARM64 E2E jobs
- reduce repeated Orchestrator downloads and Artifactory usage during PR validation

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build.yml"); YAML.load_file(".github/actions/orchestrator-cache/action.yml")'`
- `actionlint .github/workflows/build.yml` (reports only pre-existing runner-label and shellcheck issues outside this change)

## Proof
- Cache seeding run: https://github.com/SonarSource/sonar-rust/actions/runs/23043403836
  - Linux E2E job: https://github.com/SonarSource/sonar-rust/actions/runs/23043403836/job/66927284050
  - ARM64 E2E job: https://github.com/SonarSource/sonar-rust/actions/runs/23043403836/job/66927284013
  - Observed behavior: the monthly key missed on the first run (`Cache not found for input keys: e2e-2026-03-23043403836, e2e-2026-03-`) and the ARM64 E2E job saved `e2e-2026-03-23043403836`.
- Cache restore run: https://github.com/SonarSource/sonar-rust/actions/runs/23043966065
  - Linux E2E job: https://github.com/SonarSource/sonar-rust/actions/runs/23043966065/job/66929057816
  - Observed behavior: the second run restored successfully from the previous run key (`Cache hit for restore-key: e2e-2026-03-23043403836` and `Cache restored from key: e2e-2026-03-23043403836`).
- Current PR checks are green on the second run, including `Build`, all three `E2E` jobs, analysis, and `Promote`.
