### PR TITLE
RUST-115 Fix Clippy workspace path resolution

### DIFF
--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyReportSensor.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyReportSensor.java
@@ -19,7 +19,6 @@ package org.sonarsource.rust.clippy;
 import org.sonarsource.rust.common.ReportProvider;
 import org.sonarsource.rust.plugin.RustLanguage;
 import org.sonarsource.rust.plugin.Telemetry;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,8 +72,7 @@ public class ClippyReportSensor implements Sensor {
     for (var diagnostic : diagnostics) {
       try {
         LOG.debug("Saving Clippy diagnostic: {}", diagnostic);
-        var manifestDir = Path.of(diagnostic.manifest_path()).getParent();
-        saveIssue(context, diagnostic, manifestDir);
+        saveIssue(context, diagnostic);
         LOG.debug("Successfully saved Clippy diagnostic");
       } catch (Exception e) {
         LOG.warn("Failed to save Clippy diagnostic. {}", e.getMessage());
@@ -85,7 +83,7 @@ public class ClippyReportSensor implements Sensor {
   }
 
   @SuppressWarnings("deprecation")
-  private static void saveIssue(SensorContext context, ClippyDiagnostic diagnostic, Path baseDir) {
+  private static void saveIssue(SensorContext context, ClippyDiagnostic diagnostic) {
     var ruleId = diagnostic.lintId().substring("clippy::".length());
     var loader = ClippyRulesDefinition.loader();
     if (!loader.ruleKeys().contains(ruleId)) {
@@ -99,7 +97,7 @@ public class ClippyReportSensor implements Sensor {
       .severity(loader.ruleSeverity(ruleId))
       .remediationEffortMinutes(loader.ruleConstantDebtMinutes(ruleId));
 
-    var location = diagnosticToLocation(issue.newLocation(), diagnostic, context, baseDir);
+    var location = diagnosticToLocation(issue.newLocation(), diagnostic, context);
     if (location == null) {
       throw new IllegalStateException("Unknown file: " + diagnostic.message().spans().get(0).file_name());
     }

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippySensor.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippySensor.java
@@ -111,7 +111,7 @@ public class ClippySensor implements Sensor {
         var workDir = manifestPath.getParent();
         clippy.run(workDir, lints, diagnostic -> {
           try {
-            saveIssue(context, diagnostic, workDir);
+            saveIssue(context, diagnostic);
           } catch (Exception e) {
             LOG.warn("Failed to save Clippy issue: {}", diagnostic, e);
           }
@@ -130,7 +130,7 @@ public class ClippySensor implements Sensor {
     }
   }
 
-  private static void saveIssue(SensorContext context, ClippyDiagnostic diagnostic, Path workDir) {
+  private static void saveIssue(SensorContext context, ClippyDiagnostic diagnostic) {
     LOG.debug("Saving Clippy diagnostic: {}", diagnostic);
 
     String lintId = diagnostic.lintId();
@@ -143,7 +143,7 @@ public class ClippySensor implements Sensor {
     var issue = context.newIssue()
       .forRule(RuleKey.of(RustLanguage.KEY, ruleKey));
 
-    var location = diagnosticToLocation(issue.newLocation(), diagnostic, context, workDir);
+    var location = diagnosticToLocation(issue.newLocation(), diagnostic, context);
     if (location == null) {
       LOG.debug("No InputFile found for Clippy diagnostic: {}", diagnostic);
       return;

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyUtils.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyUtils.java
@@ -145,13 +145,11 @@ class ClippyUtils {
     }
 
     // Try the crate directory first, then each parent up to the analysis base directory.
-    var currentDir = manifestDir;
-    while (currentDir != null) {
+    for (var currentDir = manifestDir; ; currentDir = currentDir.getParent()) {
       addCandidate(candidates, currentDir.resolve(spanPath).normalize());
       if (currentDir.equals(baseDir)) {
         break;
       }
-      currentDir = currentDir.getParent();
     }
 
     return candidates;

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyUtils.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyUtils.java
@@ -81,12 +81,7 @@ class ClippyUtils {
   }
 
   static NewIssueLocation diagnosticToLocation(NewIssueLocation location, ClippyDiagnostic diagnostic, SensorContext context) {
-    var spans = diagnostic.message().spans();
-    if (spans.isEmpty()) {
-      throw new IllegalStateException("Empty spans");
-    }
-
-    var span = spans.get(0);
+    var span = firstSpan(diagnostic);
     var inputFile = resolveInputFile(diagnostic, context);
     if (inputFile == null) {
       return null;
@@ -101,10 +96,7 @@ class ClippyUtils {
 
   @Nullable
   static InputFile resolveInputFile(ClippyDiagnostic diagnostic, SensorContext context) {
-    var spans = diagnostic.message().spans();
-    if (spans.isEmpty()) {
-      throw new IllegalStateException("Empty spans");
-    }
+    firstSpan(diagnostic);
 
     for (var candidate : candidatePaths(diagnostic, context)) {
       var predicates = context.fileSystem().predicates().hasPath(candidate.toString());
@@ -118,12 +110,9 @@ class ClippyUtils {
   }
 
   private static List<Path> candidatePaths(ClippyDiagnostic diagnostic, SensorContext context) {
-    var spanPath = Path.of(diagnostic.message().spans().get(0).file_name()).normalize();
-    var candidates = new LinkedHashSet<Path>();
-    candidates.add(spanPath);
-
+    var spanPath = Path.of(firstSpan(diagnostic).file_name()).normalize();
     if (spanPath.isAbsolute()) {
-      return new ArrayList<>(candidates);
+      return List.of(spanPath);
     }
 
     var baseDir = context.fileSystem().baseDir().toPath().toAbsolutePath().normalize();
@@ -137,7 +126,9 @@ class ClippyUtils {
       ? manifestPath.getParent()
       : manifestPath;
 
+    var candidates = new LinkedHashSet<Path>();
     if (!manifestDir.startsWith(baseDir)) {
+      candidates.add(spanPath);
       candidates.add(manifestDir.resolve(spanPath).normalize());
       return new ArrayList<>(candidates);
     }
@@ -151,5 +142,13 @@ class ClippyUtils {
     }
 
     return new ArrayList<>(candidates);
+  }
+
+  private static ClippySpan firstSpan(ClippyDiagnostic diagnostic) {
+    var spans = diagnostic.message().spans();
+    if (spans.isEmpty()) {
+      throw new IllegalStateException("Clippy diagnostic '%s' has no location spans".formatted(diagnostic.lintId()));
+    }
+    return spans.get(0);
   }
 }

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyUtils.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyUtils.java
@@ -22,9 +22,11 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
+import org.sonar.api.batch.fs.InputFile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.sensor.SensorContext;
@@ -77,24 +79,14 @@ class ClippyUtils {
       && diagnostic.message().code().code().startsWith("clippy");
   }
 
-  static NewIssueLocation diagnosticToLocation(NewIssueLocation location, ClippyDiagnostic diagnostic, SensorContext context, Path workDir) {
+  static NewIssueLocation diagnosticToLocation(NewIssueLocation location, ClippyDiagnostic diagnostic, SensorContext context) {
     var spans = diagnostic.message().spans();
     if (spans.isEmpty()) {
       throw new IllegalStateException("Empty spans");
     }
 
     var span = spans.get(0);
-    var fileName = span.file_name();
-
-    // Clippy diagnostics are relative to the Cargo manifest directory, which might not be the same as the SonarQube project base directory.
-    // Therefore, we need to adjust the file path to make it relative to the SonarQube project base directory using the working directory.
-    var baseDir = context.fileSystem().baseDir().toPath();
-    if (!baseDir.equals(workDir)) {
-      fileName = workDir.resolve(fileName).toString();
-    }
-
-    var predicates = context.fileSystem().predicates().hasPath(fileName);
-    var inputFile = context.fileSystem().inputFile(predicates);
+    var inputFile = resolveInputFile(diagnostic, context);
     if (inputFile == null) {
       return null;
     }
@@ -104,5 +96,70 @@ class ClippyUtils {
       .at(inputFile.newRange(span.line_start(), span.column_start() - 1, span.line_end(), span.column_end() - 1));
 
     return location;
+  }
+
+  @Nullable
+  static InputFile resolveInputFile(ClippyDiagnostic diagnostic, SensorContext context) {
+    var spans = diagnostic.message().spans();
+    if (spans.isEmpty()) {
+      throw new IllegalStateException("Empty spans");
+    }
+
+    for (var candidate : candidatePaths(diagnostic, context)) {
+      var predicates = context.fileSystem().predicates().hasPath(candidate.toString());
+      var inputFile = context.fileSystem().inputFile(predicates);
+      if (inputFile != null) {
+        return inputFile;
+      }
+    }
+
+    return null;
+  }
+
+  private static List<Path> candidatePaths(ClippyDiagnostic diagnostic, SensorContext context) {
+    var spanPath = Path.of(diagnostic.message().spans().get(0).file_name()).normalize();
+    var candidates = new ArrayList<Path>();
+    addCandidate(candidates, spanPath);
+
+    if (spanPath.isAbsolute()) {
+      return candidates;
+    }
+
+    var baseDir = context.fileSystem().baseDir().toPath().toAbsolutePath().normalize();
+    var manifestPath = Path.of(diagnostic.manifest_path());
+    if (!manifestPath.isAbsolute()) {
+      manifestPath = baseDir.resolve(manifestPath);
+    }
+    manifestPath = manifestPath.normalize();
+
+    var manifestDir = manifestPath.getFileName() != null && "Cargo.toml".equals(manifestPath.getFileName().toString())
+      ? manifestPath.getParent()
+      : manifestPath;
+    if (manifestDir == null) {
+      return candidates;
+    }
+
+    if (!manifestDir.startsWith(baseDir)) {
+      addCandidate(candidates, manifestDir.resolve(spanPath).normalize());
+      return candidates;
+    }
+
+    // Try the crate directory first, then each parent up to the analysis base directory.
+    var currentDir = manifestDir;
+    while (currentDir != null) {
+      addCandidate(candidates, currentDir.resolve(spanPath).normalize());
+      if (currentDir.equals(baseDir)) {
+        break;
+      }
+      currentDir = currentDir.getParent();
+    }
+
+    return candidates;
+  }
+
+  private static void addCandidate(List<Path> candidates, Path candidate) {
+    if (!candidates.contains(candidate)) {
+      candidates.add(candidate);
+    }
   }
 }

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyUtils.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyUtils.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -118,11 +119,11 @@ class ClippyUtils {
 
   private static List<Path> candidatePaths(ClippyDiagnostic diagnostic, SensorContext context) {
     var spanPath = Path.of(diagnostic.message().spans().get(0).file_name()).normalize();
-    var candidates = new ArrayList<Path>();
-    addCandidate(candidates, spanPath);
+    var candidates = new LinkedHashSet<Path>();
+    candidates.add(spanPath);
 
     if (spanPath.isAbsolute()) {
-      return candidates;
+      return new ArrayList<>(candidates);
     }
 
     var baseDir = context.fileSystem().baseDir().toPath().toAbsolutePath().normalize();
@@ -132,32 +133,23 @@ class ClippyUtils {
     }
     manifestPath = manifestPath.normalize();
 
-    var manifestDir = manifestPath.getFileName() != null && "Cargo.toml".equals(manifestPath.getFileName().toString())
+    var manifestDir = manifestPath.endsWith("Cargo.toml")
       ? manifestPath.getParent()
       : manifestPath;
-    if (manifestDir == null) {
-      return candidates;
-    }
 
     if (!manifestDir.startsWith(baseDir)) {
-      addCandidate(candidates, manifestDir.resolve(spanPath).normalize());
-      return candidates;
+      candidates.add(manifestDir.resolve(spanPath).normalize());
+      return new ArrayList<>(candidates);
     }
 
     // Try the crate directory first, then each parent up to the analysis base directory.
     for (var currentDir = manifestDir; ; currentDir = currentDir.getParent()) {
-      addCandidate(candidates, currentDir.resolve(spanPath).normalize());
+      candidates.add(currentDir.resolve(spanPath).normalize());
       if (currentDir.equals(baseDir)) {
         break;
       }
     }
 
-    return candidates;
-  }
-
-  private static void addCandidate(List<Path> candidates, Path candidate) {
-    if (!candidates.contains(candidate)) {
-      candidates.add(candidate);
-    }
+    return new ArrayList<>(candidates);
   }
 }

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyReportSensorTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyReportSensorTest.java
@@ -216,4 +216,55 @@ class ClippyReportSensorTest {
 
     Files.delete(tempFile);
   }
+
+  @Test
+  void testSaveIssueWithWorkspaceRelativeDiagnostic() throws IOException {
+    var manifestPath = baseDir.resolve("workspace/crates/core/Cargo.toml");
+    var json = """
+      {"manifest_path": "%s",
+       "message": {
+        "code": {
+          "code": "clippy::approx_constant"
+        },
+        "message": "approximate value of `f{32, 64}::consts::PI` found",
+        "spans": [
+          {
+            "file_name": "crates/core/src/main.rs",
+            "column_end": 17,
+            "column_start": 13,
+            "line_end": 2,
+            "line_start": 2
+          }
+        ]
+      }}
+      """.formatted(manifestPath.toString()).replaceAll(System.lineSeparator(), "");
+    var tempFile = Files.createTempFile(baseDir, "clippy_report", ".json");
+    Files.writeString(tempFile, json);
+
+    var context = SensorContextTester.create(baseDir);
+    context.settings().setProperty(ClippyReportSensor.CLIPPY_REPORT_PATHS, tempFile.toString());
+
+    var sourceCode = """
+      fn main() {
+          let x = 3.14;
+      }
+      """;
+    context.fileSystem().add(
+      new TestInputFileBuilder("moduleKey", "workspace/crates/core/src/main.rs")
+        .setLanguage(RustLanguage.KEY)
+        .setContents(sourceCode)
+        .build());
+
+    var sensor = new ClippyReportSensor();
+    sensor.execute(context);
+
+    var issues = context.allExternalIssues();
+    assertThat(issues).hasSize(1);
+
+    var issue = issues.iterator().next();
+    assertThat(issue.ruleId()).isEqualTo("approx_constant");
+    assertThat(issue.primaryLocation().message()).isEqualTo("approximate value of `f{32, 64}::consts::PI` found");
+
+    Files.delete(tempFile);
+  }
 }

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyReportSensorTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyReportSensorTest.java
@@ -267,4 +267,39 @@ class ClippyReportSensorTest {
 
     Files.delete(tempFile);
   }
+
+  @Test
+  void testExecuteContinuesAfterDiagnosticResolutionFailure() throws IOException {
+    var manifestPath = baseDir.resolve("Cargo.toml");
+    var json = """
+      {"manifest_path":"%s","message":{"code":{"code":"clippy::approx_constant"},"message":"invalid path","spans":[]}}
+      {"manifest_path":"%s","message":{"code":{"code":"clippy::approx_constant"},"message":"approximate value of `f{32, 64}::consts::PI` found","spans":[{"file_name":"src/main.rs","column_end":17,"column_start":13,"line_end":2,"line_start":2}]}}
+      """.formatted(manifestPath, manifestPath);
+    var tempFile = Files.createTempFile(baseDir, "clippy_report", ".json");
+    Files.writeString(tempFile, json);
+
+    var context = SensorContextTester.create(baseDir);
+    context.settings().setProperty(ClippyReportSensor.CLIPPY_REPORT_PATHS, tempFile.toString());
+
+    var sourceCode = """
+      fn main() {
+          let x = 3.14;
+      }
+      """;
+    context.fileSystem().add(
+      new TestInputFileBuilder("moduleKey", "src/main.rs")
+        .setLanguage(RustLanguage.KEY)
+        .setContents(sourceCode)
+        .build());
+
+    var sensor = new ClippyReportSensor();
+    sensor.execute(context);
+
+    assertThat(logTester.logs()).contains("Failed to save Clippy diagnostic. Empty spans");
+    var issues = context.allExternalIssues();
+    assertThat(issues).hasSize(1);
+    assertThat(issues.iterator().next().primaryLocation().message()).isEqualTo("approximate value of `f{32, 64}::consts::PI` found");
+
+    Files.delete(tempFile);
+  }
 }

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyReportSensorTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyReportSensorTest.java
@@ -98,7 +98,7 @@ class ClippyReportSensorTest {
     var sensor = new ClippyReportSensor();
     sensor.execute(context);
 
-    assertThat(logTester.logs()).contains("Failed to save Clippy diagnostic. Empty spans");
+    assertThat(logTester.logs()).contains("Failed to save Clippy diagnostic. Clippy diagnostic 'clippy::approx_constant' has no location spans");
 
     Files.delete(tempFile);
   }
@@ -295,7 +295,7 @@ class ClippyReportSensorTest {
     var sensor = new ClippyReportSensor();
     sensor.execute(context);
 
-    assertThat(logTester.logs()).contains("Failed to save Clippy diagnostic. Empty spans");
+    assertThat(logTester.logs()).contains("Failed to save Clippy diagnostic. Clippy diagnostic 'clippy::approx_constant' has no location spans");
     var issues = context.allExternalIssues();
     assertThat(issues).hasSize(1);
     assertThat(issues.iterator().next().primaryLocation().message()).isEqualTo("approximate value of `f{32, 64}::consts::PI` found");

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyUtilsTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyUtilsTest.java
@@ -149,6 +149,21 @@ class ClippyUtilsTest {
   }
 
   @Test
+  void resolveInputFilePrefersManifestRelativePathOverRepositoryRelativePath() throws IOException {
+    var baseDir = Files.createDirectories(temp.resolve("project"));
+    var context = SensorContextTester.create(baseDir);
+    context.fileSystem().add(inputFile(baseDir, "src/main.rs", "fn main() { println!(\"root\"); }\n"));
+    context.fileSystem().add(inputFile(baseDir, "subproj/src/main.rs", "fn main() { println!(\"subproj\"); }\n"));
+
+    var diagnostic = diagnostic(baseDir.resolve("subproj/Cargo.toml"), "src/main.rs");
+
+    var inputFile = ClippyUtils.resolveInputFile(diagnostic, context);
+
+    assertThat(inputFile).isNotNull();
+    assertThat(inputFile.uri().getPath()).endsWith("/subproj/src/main.rs");
+  }
+
+  @Test
   void resolveInputFileWithAbsoluteSpanPath() throws IOException {
     var baseDir = Files.createDirectories(temp.resolve("project"));
     var context = SensorContextTester.create(baseDir);

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyUtilsTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyUtilsTest.java
@@ -145,7 +145,7 @@ class ClippyUtilsTest {
     var inputFile = ClippyUtils.resolveInputFile(diagnostic, context);
 
     assertThat(inputFile).isNotNull();
-    assertThat(inputFile.relativePath()).isEqualTo("subproj/src/main.rs");
+    assertThat(inputFile.uri().getPath()).endsWith("/subproj/src/main.rs");
   }
 
   @Test
@@ -159,7 +159,7 @@ class ClippyUtilsTest {
     var inputFile = ClippyUtils.resolveInputFile(diagnostic, context);
 
     assertThat(inputFile).isNotNull();
-    assertThat(inputFile.relativePath()).isEqualTo("workspace/crates/core/src/main.rs");
+    assertThat(inputFile.uri().getPath()).endsWith("/workspace/crates/core/src/main.rs");
   }
 
   @Test
@@ -174,7 +174,7 @@ class ClippyUtilsTest {
     var inputFile = ClippyUtils.resolveInputFile(diagnostic, context);
 
     assertThat(inputFile).isNotNull();
-    assertThat(inputFile.relativePath()).isEqualTo("subproj/src/main.rs");
+    assertThat(inputFile.uri().getPath()).endsWith("/subproj/src/main.rs");
   }
 
   private static InputFile inputFile(Path baseDir, String relativePath, String contents) {

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyUtilsTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyUtilsTest.java
@@ -25,9 +25,14 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
+import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonarsource.rust.plugin.RustLanguage;
 
 class ClippyUtilsTest {
 
@@ -127,5 +132,65 @@ class ClippyUtilsTest {
     assertThat(diagnostics).hasSize(1);
     var empty = ClippyUtils.parse(Stream.of(""));
     assertThat(empty).isEmpty();
+  }
+
+  @Test
+  void resolveInputFileRelativeToManifestDirectory() throws IOException {
+    var baseDir = Files.createDirectories(temp.resolve("project"));
+    var context = SensorContextTester.create(baseDir);
+    context.fileSystem().add(inputFile(baseDir, "subproj/src/main.rs", "fn main() {}\n"));
+
+    var diagnostic = diagnostic(baseDir.resolve("subproj/Cargo.toml"), "src/main.rs");
+
+    var inputFile = ClippyUtils.resolveInputFile(diagnostic, context);
+
+    assertThat(inputFile).isNotNull();
+    assertThat(inputFile.relativePath()).isEqualTo("subproj/src/main.rs");
+  }
+
+  @Test
+  void resolveInputFileRelativeToWorkspaceRootAncestor() throws IOException {
+    var baseDir = Files.createDirectories(temp.resolve("project"));
+    var context = SensorContextTester.create(baseDir);
+    context.fileSystem().add(inputFile(baseDir, "workspace/crates/core/src/main.rs", "fn main() {}\n"));
+
+    var diagnostic = diagnostic(baseDir.resolve("workspace/crates/core/Cargo.toml"), "crates/core/src/main.rs");
+
+    var inputFile = ClippyUtils.resolveInputFile(diagnostic, context);
+
+    assertThat(inputFile).isNotNull();
+    assertThat(inputFile.relativePath()).isEqualTo("workspace/crates/core/src/main.rs");
+  }
+
+  @Test
+  void resolveInputFileUsingRepositoryRelativePathFirst() throws IOException {
+    var analysisBaseDir = Files.createDirectories(temp.resolve("project"));
+    var context = SensorContextTester.create(analysisBaseDir);
+    context.fileSystem().add(inputFile(analysisBaseDir, "subproj/src/main.rs", "fn main() {}\n"));
+
+    var manifestBaseDir = Files.createDirectories(temp.resolve("other-project"));
+    var diagnostic = diagnostic(manifestBaseDir.resolve("crate/Cargo.toml"), "subproj/src/main.rs");
+
+    var inputFile = ClippyUtils.resolveInputFile(diagnostic, context);
+
+    assertThat(inputFile).isNotNull();
+    assertThat(inputFile.relativePath()).isEqualTo("subproj/src/main.rs");
+  }
+
+  private static InputFile inputFile(Path baseDir, String relativePath, String contents) {
+    return TestInputFileBuilder.create("module", relativePath)
+      .setModuleBaseDir(baseDir)
+      .setLanguage(RustLanguage.KEY)
+      .setContents(contents)
+      .build();
+  }
+
+  private static ClippyDiagnostic diagnostic(Path manifestPath, String fileName) {
+    return new ClippyDiagnostic(
+      manifestPath.toString(),
+      new ClippyMessage(
+        new ClippyCode("clippy::some_lint"),
+        "message",
+        List.of(new ClippySpan(fileName, 1, 1, 1, 2))));
   }
 }

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyUtilsTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyUtilsTest.java
@@ -149,12 +149,40 @@ class ClippyUtilsTest {
   }
 
   @Test
+  void resolveInputFileWithAbsoluteSpanPath() throws IOException {
+    var baseDir = Files.createDirectories(temp.resolve("project"));
+    var context = SensorContextTester.create(baseDir);
+    context.fileSystem().add(inputFile(baseDir, "subproj/src/main.rs", "fn main() {}\n"));
+
+    var diagnostic = diagnostic(baseDir.resolve("subproj/Cargo.toml"), baseDir.resolve("subproj/src/main.rs").toString());
+
+    var inputFile = ClippyUtils.resolveInputFile(diagnostic, context);
+
+    assertThat(inputFile).isNotNull();
+    assertThat(inputFile.uri().getPath()).endsWith("/subproj/src/main.rs");
+  }
+
+  @Test
   void resolveInputFileRelativeToWorkspaceRootAncestor() throws IOException {
     var baseDir = Files.createDirectories(temp.resolve("project"));
     var context = SensorContextTester.create(baseDir);
     context.fileSystem().add(inputFile(baseDir, "workspace/crates/core/src/main.rs", "fn main() {}\n"));
 
     var diagnostic = diagnostic(baseDir.resolve("workspace/crates/core/Cargo.toml"), "crates/core/src/main.rs");
+
+    var inputFile = ClippyUtils.resolveInputFile(diagnostic, context);
+
+    assertThat(inputFile).isNotNull();
+    assertThat(inputFile.uri().getPath()).endsWith("/workspace/crates/core/src/main.rs");
+  }
+
+  @Test
+  void resolveInputFileWithRelativeManifestPath() throws IOException {
+    var baseDir = Files.createDirectories(temp.resolve("project"));
+    var context = SensorContextTester.create(baseDir);
+    context.fileSystem().add(inputFile(baseDir, "workspace/crates/core/src/main.rs", "fn main() {}\n"));
+
+    var diagnostic = diagnostic("workspace/crates/core/Cargo.toml", "crates/core/src/main.rs");
 
     var inputFile = ClippyUtils.resolveInputFile(diagnostic, context);
 
@@ -186,8 +214,12 @@ class ClippyUtilsTest {
   }
 
   private static ClippyDiagnostic diagnostic(Path manifestPath, String fileName) {
+    return diagnostic(manifestPath.toString(), fileName);
+  }
+
+  private static ClippyDiagnostic diagnostic(String manifestPath, String fileName) {
     return new ClippyDiagnostic(
-      manifestPath.toString(),
+      manifestPath,
       new ClippyMessage(
         new ClippyCode("clippy::some_lint"),
         "message",


### PR DESCRIPTION
## Summary

- fix Clippy path resolution when diagnostics use workspace-relative paths from nested Cargo workspaces
- move file lookup to a shared resolver used by both the external Clippy report import and the in-process Clippy sensor
- try span paths as-is first, then relative to the manifest directory, then relative to ancestor directories up to the analysis base directory

## Changes

- update Clippy issue location resolution to support repository-relative, crate-relative, and workspace-relative paths
- keep existing unknown-file behavior when no indexed file matches
- add regression coverage for nested workspace imports and shared resolver behavior
