### PR TITLE
RUST-118 Surface actionable Clippy report import warnings

### DIFF
--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyImportException.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyImportException.java
@@ -1,0 +1,58 @@
+/*
+ * SonarQube Rust Plugin
+ * Copyright (C) 2025-2026 SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.rust.clippy;
+
+class ClippyImportException extends RuntimeException {
+
+  enum Category {
+    UNKNOWN_RULE,
+    UNKNOWN_FILE,
+    INVALID_DIAGNOSTIC
+  }
+
+  private final Category category;
+
+  private ClippyImportException(Category category, String message) {
+    super(message);
+    this.category = category;
+  }
+
+  private ClippyImportException(Category category, String message, Throwable cause) {
+    super(message, cause);
+    this.category = category;
+  }
+
+  Category category() {
+    return category;
+  }
+
+  static ClippyImportException unknownRule(String ruleId) {
+    return new ClippyImportException(Category.UNKNOWN_RULE, "Unknown rule: " + ruleId);
+  }
+
+  static ClippyImportException unknownFile(String fileName) {
+    return new ClippyImportException(Category.UNKNOWN_FILE, "Unknown file: " + fileName);
+  }
+
+  static ClippyImportException invalidDiagnostic(String message) {
+    return new ClippyImportException(Category.INVALID_DIAGNOSTIC, message);
+  }
+
+  static ClippyImportException invalidDiagnostic(String message, Throwable cause) {
+    return new ClippyImportException(Category.INVALID_DIAGNOSTIC, message, cause);
+  }
+}

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyReportSensor.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyReportSensor.java
@@ -41,10 +41,6 @@ public class ClippyReportSensor implements Sensor {
 
   private final AnalysisWarningsWrapper analysisWarnings;
 
-  public ClippyReportSensor() {
-    this(new AnalysisWarningsWrapper());
-  }
-
   public ClippyReportSensor(AnalysisWarningsWrapper analysisWarnings) {
     this.analysisWarnings = analysisWarnings;
   }

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyReportSensor.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyReportSensor.java
@@ -17,6 +17,7 @@
 package org.sonarsource.rust.clippy;
 
 import org.sonarsource.rust.common.ReportProvider;
+import org.sonarsource.rust.plugin.AnalysisWarningsWrapper;
 import org.sonarsource.rust.plugin.RustLanguage;
 import org.sonarsource.rust.plugin.Telemetry;
 import java.util.ArrayList;
@@ -31,8 +32,22 @@ import static org.sonarsource.rust.clippy.ClippyUtils.diagnosticToLocation;
 public class ClippyReportSensor implements Sensor {
 
   private static final Logger LOG = LoggerFactory.getLogger(ClippyReportSensor.class);
+  private static final String MISSING_REPORT_WARNING = "No Clippy report files found. Check sonar.rust.clippyReport.reportPaths.";
+  private static final String INVALID_REPORT_WARNING = "At least one Clippy report could not be read or parsed. See logs for details.";
+  private static final String UNKNOWN_FILE_WARNING = "Some Clippy diagnostics refer to files that are not part of the analyzed project.";
+  private static final String GENERIC_IMPORT_WARNING = "Some Clippy diagnostics could not be imported; see logs for details.";
 
   public static final String CLIPPY_REPORT_PATHS = "sonar.rust.clippyReport.reportPaths";
+
+  private final AnalysisWarningsWrapper analysisWarnings;
+
+  public ClippyReportSensor() {
+    this(new AnalysisWarningsWrapper());
+  }
+
+  public ClippyReportSensor(AnalysisWarningsWrapper analysisWarnings) {
+    this.analysisWarnings = analysisWarnings;
+  }
 
   @Override
   public void describe(SensorDescriptor descriptor) {
@@ -52,6 +67,7 @@ public class ClippyReportSensor implements Sensor {
     var reportFiles = reportProvider.getReportFiles(context);
     if (reportFiles.isEmpty()) {
       LOG.warn("No Clippy report files found");
+      analysisWarnings.addUnique(MISSING_REPORT_WARNING);
       return;
     } else {
       LOG.debug("Found {} Clippy report files", reportFiles.size());
@@ -66,6 +82,7 @@ public class ClippyReportSensor implements Sensor {
         LOG.debug("Successfully parsed Clippy report");
       } catch (Exception e) {
         LOG.error("Failed to parse Clippy report", e);
+        analysisWarnings.addUnique(INVALID_REPORT_WARNING);
       }
     }
 
@@ -74,12 +91,29 @@ public class ClippyReportSensor implements Sensor {
         LOG.debug("Saving Clippy diagnostic: {}", diagnostic);
         saveIssue(context, diagnostic);
         LOG.debug("Successfully saved Clippy diagnostic");
-      } catch (Exception e) {
+      } catch (ClippyImportException e) {
         LOG.warn("Failed to save Clippy diagnostic. {}", e.getMessage());
+        addWarning(e.category());
+      } catch (Exception e) {
+        LOG.warn("Failed to save Clippy diagnostic. {}", e.getMessage(), e);
+        analysisWarnings.addUnique(GENERIC_IMPORT_WARNING);
       }
     }
 
     LOG.debug("Processed Clippy reports");
+  }
+
+  private void addWarning(ClippyImportException.Category category) {
+    switch (category) {
+      case UNKNOWN_RULE:
+        return;
+      case UNKNOWN_FILE:
+        analysisWarnings.addUnique(UNKNOWN_FILE_WARNING);
+        return;
+      case INVALID_DIAGNOSTIC:
+        analysisWarnings.addUnique(GENERIC_IMPORT_WARNING);
+        return;
+    }
   }
 
   @SuppressWarnings("deprecation")
@@ -87,7 +121,7 @@ public class ClippyReportSensor implements Sensor {
     var ruleId = diagnostic.lintId().substring("clippy::".length());
     var loader = ClippyRulesDefinition.loader();
     if (!loader.ruleKeys().contains(ruleId)) {
-      throw new IllegalStateException("Unknown rule: " + ruleId);
+      throw ClippyImportException.unknownRule(ruleId);
     }
 
     var issue = context.newExternalIssue()
@@ -99,7 +133,7 @@ public class ClippyReportSensor implements Sensor {
 
     var location = diagnosticToLocation(issue.newLocation(), diagnostic, context);
     if (location == null) {
-      throw new IllegalStateException("Unknown file: " + diagnostic.message().spans().get(0).file_name());
+      throw ClippyImportException.unknownFile(diagnostic.message().spans().get(0).file_name());
     }
 
     location.message(diagnostic.message().message());

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyUtils.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyUtils.java
@@ -87,9 +87,13 @@ class ClippyUtils {
       return null;
     }
 
-    location
-      .on(inputFile)
-      .at(inputFile.newRange(span.line_start(), span.column_start() - 1, span.line_end(), span.column_end() - 1));
+    try {
+      location
+        .on(inputFile)
+        .at(inputFile.newRange(span.line_start(), span.column_start() - 1, span.line_end(), span.column_end() - 1));
+    } catch (RuntimeException e) {
+      throw ClippyImportException.invalidDiagnostic("Invalid location for file: " + span.file_name(), e);
+    }
 
     return location;
   }
@@ -110,21 +114,20 @@ class ClippyUtils {
   }
 
   private static List<Path> candidatePaths(ClippyDiagnostic diagnostic, SensorContext context) {
-    var spanPath = Path.of(firstSpan(diagnostic).file_name()).normalize();
+    var spanPath = spanPath(diagnostic);
     if (spanPath.isAbsolute()) {
       return List.of(spanPath);
     }
 
     var baseDir = context.fileSystem().baseDir().toPath().toAbsolutePath().normalize();
-    var manifestPath = Path.of(diagnostic.manifest_path());
-    if (!manifestPath.isAbsolute()) {
-      manifestPath = baseDir.resolve(manifestPath);
-    }
-    manifestPath = manifestPath.normalize();
+    var manifestPath = manifestPath(diagnostic, baseDir);
 
     var manifestDir = manifestPath.endsWith("Cargo.toml")
       ? manifestPath.getParent()
       : manifestPath;
+    if (manifestDir == null) {
+      throw ClippyImportException.invalidDiagnostic("Invalid manifest path: " + diagnostic.manifest_path());
+    }
 
     var candidates = new LinkedHashSet<Path>();
     if (!manifestDir.startsWith(baseDir)) {
@@ -144,10 +147,35 @@ class ClippyUtils {
     return new ArrayList<>(candidates);
   }
 
+  private static Path spanPath(ClippyDiagnostic diagnostic) {
+    var fileName = firstSpan(diagnostic).file_name();
+    if (fileName == null || fileName.isBlank()) {
+      throw ClippyImportException.invalidDiagnostic("Clippy diagnostic '%s' has no file path".formatted(diagnostic.lintId()));
+    }
+
+    try {
+      return Path.of(fileName).normalize();
+    } catch (RuntimeException e) {
+      throw ClippyImportException.invalidDiagnostic("Invalid file path: " + fileName, e);
+    }
+  }
+
+  private static Path manifestPath(ClippyDiagnostic diagnostic, Path baseDir) {
+    try {
+      var manifestPath = Path.of(diagnostic.manifest_path());
+      if (!manifestPath.isAbsolute()) {
+        manifestPath = baseDir.resolve(manifestPath);
+      }
+      return manifestPath.normalize();
+    } catch (RuntimeException e) {
+      throw ClippyImportException.invalidDiagnostic("Invalid manifest path: " + diagnostic.manifest_path(), e);
+    }
+  }
+
   private static ClippySpan firstSpan(ClippyDiagnostic diagnostic) {
     var spans = diagnostic.message().spans();
-    if (spans.isEmpty()) {
-      throw new IllegalStateException("Clippy diagnostic '%s' has no location spans".formatted(diagnostic.lintId()));
+    if (spans == null || spans.isEmpty()) {
+      throw ClippyImportException.invalidDiagnostic("Clippy diagnostic '%s' has no location spans".formatted(diagnostic.lintId()));
     }
     return spans.get(0);
   }

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/TestAnalysisWarnigs.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/TestAnalysisWarnigs.java
@@ -26,6 +26,8 @@ public class TestAnalysisWarnigs implements AnalysisWarnings {
 
   @Override
   public void addUnique(String text) {
-    warnings.add(text);
+    if (!warnings.contains(text)) {
+      warnings.add(text);
+    }
   }
 }

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyReportSensorTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyReportSensorTest.java
@@ -16,6 +16,8 @@
  */
 package org.sonarsource.rust.clippy;
 
+import org.sonarsource.rust.TestAnalysisWarnigs;
+import org.sonarsource.rust.plugin.AnalysisWarningsWrapper;
 import org.sonarsource.rust.plugin.RustLanguage;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -33,6 +35,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ClippyReportSensorTest {
 
+  private static final String MISSING_REPORT_WARNING = "No Clippy report files found. Check sonar.rust.clippyReport.reportPaths.";
+  private static final String INVALID_REPORT_WARNING = "At least one Clippy report could not be read or parsed. See logs for details.";
+  private static final String UNKNOWN_FILE_WARNING = "Some Clippy diagnostics refer to files that are not part of the analyzed project.";
+  private static final String GENERIC_IMPORT_WARNING = "Some Clippy diagnostics could not be imported; see logs for details.";
+
   @RegisterExtension
   final LogTesterJUnit5 logTester = new LogTesterJUnit5().setLevel(Level.WARN);
 
@@ -41,7 +48,7 @@ class ClippyReportSensorTest {
 
   @Test
   void testDescribe() {
-    var sensor = new ClippyReportSensor();
+    var sensor = new ClippyReportSensor(new AnalysisWarningsWrapper());
     var descriptor = new DefaultSensorDescriptor();
     sensor.describe(descriptor);
 
@@ -52,11 +59,14 @@ class ClippyReportSensorTest {
 
   @Test
   void testExecuteWithNoReportsFound() {
+    var warnings = new TestAnalysisWarnigs();
     var context = SensorContextTester.create(baseDir);
-    var sensor = new ClippyReportSensor();
+    context.settings().setProperty(ClippyReportSensor.CLIPPY_REPORT_PATHS, "missing-report.json");
+    var sensor = sensor(warnings);
     sensor.execute(context);
 
     assertThat(logTester.logs()).contains("No Clippy report files found");
+    assertThat(warnings.warnings).containsExactly(MISSING_REPORT_WARNING);
   }
 
   @Test
@@ -64,22 +74,25 @@ class ClippyReportSensorTest {
     var json = """
       {"message": {
       """;
+    var warnings = new TestAnalysisWarnigs();
     var tempFile = Files.createTempFile(baseDir, "clippy_report", ".json");
     Files.writeString(tempFile, json);
 
     var context = SensorContextTester.create(baseDir);
     context.settings().setProperty(ClippyReportSensor.CLIPPY_REPORT_PATHS, tempFile.toString());
 
-    var sensor = new ClippyReportSensor();
+    var sensor = sensor(warnings);
     sensor.execute(context);
 
     assertThat(logTester.logs()).contains("Failed to parse Clippy report");
+    assertThat(warnings.warnings).containsExactly(INVALID_REPORT_WARNING);
 
     Files.delete(tempFile);
   }
 
   @Test
   void testSaveIssueWithDiagnosticEmptySpans() throws IOException {
+    var warnings = new TestAnalysisWarnigs();
     var json = """
       {"manifest_path": "/dir/Cargo.toml",
        "message": {
@@ -95,16 +108,18 @@ class ClippyReportSensorTest {
     var context = SensorContextTester.create(baseDir);
     context.settings().setProperty(ClippyReportSensor.CLIPPY_REPORT_PATHS, tempFile.toString());
 
-    var sensor = new ClippyReportSensor();
+    var sensor = sensor(warnings);
     sensor.execute(context);
 
     assertThat(logTester.logs()).contains("Failed to save Clippy diagnostic. Clippy diagnostic 'clippy::approx_constant' has no location spans");
+    assertThat(warnings.warnings).containsExactly(GENERIC_IMPORT_WARNING);
 
     Files.delete(tempFile);
   }
 
   @Test
   void testSaveIssueWithUnknownFile() throws IOException {
+    var warnings = new TestAnalysisWarnigs();
     var json = """
       {"manifest_path": "/dir/Cargo.toml",
        "message": {
@@ -124,16 +139,18 @@ class ClippyReportSensorTest {
     var context = SensorContextTester.create(baseDir);
     context.settings().setProperty(ClippyReportSensor.CLIPPY_REPORT_PATHS, tempFile.toString());
 
-    var sensor = new ClippyReportSensor();
+    var sensor = sensor(warnings);
     sensor.execute(context);
 
     assertThat(logTester.logs()).contains("Failed to save Clippy diagnostic. Unknown file: src/main.rs");
+    assertThat(warnings.warnings).containsExactly(UNKNOWN_FILE_WARNING);
 
     Files.delete(tempFile);
   }
 
   @Test
   void testSaveIssueWithUnknownRule() throws IOException {
+    var warnings = new TestAnalysisWarnigs();
     var json = """
       {"manifest_path": "/dir/Cargo.toml",
        "message": {
@@ -154,16 +171,93 @@ class ClippyReportSensorTest {
     context.settings().setProperty(ClippyReportSensor.CLIPPY_REPORT_PATHS, tempFile.toString());
     context.fileSystem().add(new TestInputFileBuilder("moduleKey", "src/main.rs").build());
 
-    var sensor = new ClippyReportSensor();
+    var sensor = sensor(warnings);
     sensor.execute(context);
 
     assertThat(logTester.logs()).contains("Failed to save Clippy diagnostic. Unknown rule: unknown_rule");
+    assertThat(warnings.warnings).isEmpty();
+
+    Files.delete(tempFile);
+  }
+
+  @Test
+  void testSaveIssueWithInvalidManifestPath() throws IOException {
+    var warnings = new TestAnalysisWarnigs();
+    var json = """
+      {"manifest_path": "\\u0000",
+       "message": {
+        "code": {
+          "code": "clippy::approx_constant"
+        },
+        "spans": [
+          {
+            "file_name": "src/main.rs"
+          }
+        ]
+      }}
+      """.replaceAll(System.lineSeparator(), "");
+    var tempFile = Files.createTempFile(baseDir, "clippy_report", ".json");
+    Files.writeString(tempFile, json);
+
+    var context = SensorContextTester.create(baseDir);
+    context.settings().setProperty(ClippyReportSensor.CLIPPY_REPORT_PATHS, tempFile.toString());
+
+    var sensor = sensor(warnings);
+    sensor.execute(context);
+
+    assertThat(logTester.logs()).contains("Failed to save Clippy diagnostic. Invalid manifest path: \u0000");
+    assertThat(warnings.warnings).containsExactly(GENERIC_IMPORT_WARNING);
+
+    Files.delete(tempFile);
+  }
+
+  @Test
+  void testWarningsAreDeduplicatedPerCategory() throws IOException {
+    var warnings = new TestAnalysisWarnigs();
+    var json = String.join(System.lineSeparator(),
+      """
+      {"manifest_path": "/dir/Cargo.toml",
+       "message": {
+        "code": {
+          "code": "clippy::approx_constant"
+        },
+        "spans": [
+          {
+            "file_name": "src/first.rs"
+          }
+        ]
+      }}
+      """.replaceAll(System.lineSeparator(), ""),
+      """
+      {"manifest_path": "/dir/Cargo.toml",
+       "message": {
+        "code": {
+          "code": "clippy::approx_constant"
+        },
+        "spans": [
+          {
+            "file_name": "src/second.rs"
+          }
+        ]
+      }}
+      """.replaceAll(System.lineSeparator(), ""));
+    var tempFile = Files.createTempFile(baseDir, "clippy_report", ".json");
+    Files.writeString(tempFile, json);
+
+    var context = SensorContextTester.create(baseDir);
+    context.settings().setProperty(ClippyReportSensor.CLIPPY_REPORT_PATHS, tempFile.toString());
+
+    var sensor = sensor(warnings);
+    sensor.execute(context);
+
+    assertThat(warnings.warnings).containsExactly(UNKNOWN_FILE_WARNING);
 
     Files.delete(tempFile);
   }
 
   @Test
   void testSaveIssueWithValidDiagnostic() throws IOException {
+    var warnings = new TestAnalysisWarnigs();
     var manifestPath = baseDir.resolve("Cargo.toml");
     var json = """
       {"manifest_path": "%s",
@@ -200,11 +294,12 @@ class ClippyReportSensorTest {
       .setContents(sourceCode)
       .build());
 
-    var sensor = new ClippyReportSensor();
+    var sensor = sensor(warnings);
     sensor.execute(context);
 
     var issues = context.allExternalIssues();
     assertThat(issues).hasSize(1);
+    assertThat(warnings.warnings).isEmpty();
 
     var issue = issues.iterator().next();
     assertThat(issue.ruleId()).isEqualTo("approx_constant");
@@ -219,6 +314,7 @@ class ClippyReportSensorTest {
 
   @Test
   void testSaveIssueWithWorkspaceRelativeDiagnostic() throws IOException {
+    var warnings = new TestAnalysisWarnigs();
     var manifestPath = baseDir.resolve("workspace/crates/core/Cargo.toml");
     var json = """
       {"manifest_path": "%s",
@@ -255,11 +351,12 @@ class ClippyReportSensorTest {
         .setContents(sourceCode)
         .build());
 
-    var sensor = new ClippyReportSensor();
+    var sensor = sensor(warnings);
     sensor.execute(context);
 
     var issues = context.allExternalIssues();
     assertThat(issues).hasSize(1);
+    assertThat(warnings.warnings).isEmpty();
 
     var issue = issues.iterator().next();
     assertThat(issue.ruleId()).isEqualTo("approx_constant");
@@ -270,6 +367,7 @@ class ClippyReportSensorTest {
 
   @Test
   void testExecuteContinuesAfterDiagnosticResolutionFailure() throws IOException {
+    var warnings = new TestAnalysisWarnigs();
     var manifestPath = baseDir.resolve("Cargo.toml");
     var json = """
       {"manifest_path":"%s","message":{"code":{"code":"clippy::approx_constant"},"message":"invalid path","spans":[]}}
@@ -292,14 +390,19 @@ class ClippyReportSensorTest {
         .setContents(sourceCode)
         .build());
 
-    var sensor = new ClippyReportSensor();
+    var sensor = sensor(warnings);
     sensor.execute(context);
 
     assertThat(logTester.logs()).contains("Failed to save Clippy diagnostic. Clippy diagnostic 'clippy::approx_constant' has no location spans");
+    assertThat(warnings.warnings).containsExactly(GENERIC_IMPORT_WARNING);
     var issues = context.allExternalIssues();
     assertThat(issues).hasSize(1);
     assertThat(issues.iterator().next().primaryLocation().message()).isEqualTo("approximate value of `f{32, 64}::consts::PI` found");
 
     Files.delete(tempFile);
+  }
+
+  private static ClippyReportSensor sensor(TestAnalysisWarnigs warnings) {
+    return new ClippyReportSensor(new AnalysisWarningsWrapper(warnings));
   }
 }

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyReportSensorTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyReportSensorTest.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
 import org.slf4j.event.Level;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
@@ -48,7 +49,7 @@ class ClippyReportSensorTest {
 
   @Test
   void testDescribe() {
-    var sensor = new ClippyReportSensor(new AnalysisWarningsWrapper());
+    var sensor = new ClippyReportSensor();
     var descriptor = new DefaultSensorDescriptor();
     sensor.describe(descriptor);
 
@@ -398,6 +399,47 @@ class ClippyReportSensorTest {
     var issues = context.allExternalIssues();
     assertThat(issues).hasSize(1);
     assertThat(issues.iterator().next().primaryLocation().message()).isEqualTo("approximate value of `f{32, 64}::consts::PI` found");
+
+    Files.delete(tempFile);
+  }
+
+  @Test
+  void testExecuteContinuesAfterUnexpectedIssueCreationFailure() throws IOException {
+    var warnings = new TestAnalysisWarnigs();
+    var manifestPath = baseDir.resolve("Cargo.toml");
+    var json = """
+      {"manifest_path":"%s","message":{"code":{"code":"clippy::approx_constant"},"message":"first diagnostic","spans":[{"file_name":"src/main.rs","column_end":17,"column_start":13,"line_end":2,"line_start":2}]}}
+      {"manifest_path":"%s","message":{"code":{"code":"clippy::approx_constant"},"message":"second diagnostic","spans":[{"file_name":"src/main.rs","column_end":17,"column_start":13,"line_end":2,"line_start":2}]}}
+      """.formatted(manifestPath, manifestPath);
+    var tempFile = Files.createTempFile(baseDir, "clippy_report", ".json");
+    Files.writeString(tempFile, json);
+
+    var context = Mockito.spy(SensorContextTester.create(baseDir));
+    context.settings().setProperty(ClippyReportSensor.CLIPPY_REPORT_PATHS, tempFile.toString());
+
+    var sourceCode = """
+      fn main() {
+          let x = 3.14;
+      }
+      """;
+    context.fileSystem().add(
+      new TestInputFileBuilder("moduleKey", "src/main.rs")
+        .setLanguage(RustLanguage.KEY)
+        .setContents(sourceCode)
+        .build());
+    Mockito.doThrow(new IllegalStateException("Unexpected failure"))
+      .doCallRealMethod()
+      .when(context)
+      .newExternalIssue();
+
+    var sensor = sensor(warnings);
+    sensor.execute(context);
+
+    assertThat(logTester.logs()).contains("Failed to save Clippy diagnostic. Unexpected failure");
+    assertThat(warnings.warnings).containsExactly(GENERIC_IMPORT_WARNING);
+    var issues = context.allExternalIssues();
+    assertThat(issues).hasSize(1);
+    assertThat(issues.iterator().next().primaryLocation().message()).isEqualTo("second diagnostic");
 
     Files.delete(tempFile);
   }

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyReportSensorTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyReportSensorTest.java
@@ -49,7 +49,7 @@ class ClippyReportSensorTest {
 
   @Test
   void testDescribe() {
-    var sensor = new ClippyReportSensor();
+    var sensor = new ClippyReportSensor(new AnalysisWarningsWrapper());
     var descriptor = new DefaultSensorDescriptor();
     sensor.describe(descriptor);
 

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyUtilsTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyUtilsTest.java
@@ -29,8 +29,10 @@ import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
+import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonarsource.rust.plugin.RustLanguage;
 
@@ -220,6 +222,68 @@ class ClippyUtilsTest {
     assertThat(inputFile.uri().getPath()).endsWith("/subproj/src/main.rs");
   }
 
+  @Test
+  void resolveInputFileWithManifestPathWithoutParentThrows() {
+    var baseDir = Mockito.mock(Path.class);
+    var manifestPath = Mockito.mock(Path.class);
+    var fileSystem = Mockito.mock(org.sonar.api.batch.fs.FileSystem.class);
+    var context = Mockito.mock(SensorContext.class);
+    var baseDirFile = new File("ignored") {
+      @Override
+      public Path toPath() {
+        return baseDir;
+      }
+    };
+
+    Mockito.when(context.fileSystem()).thenReturn(fileSystem);
+    Mockito.when(fileSystem.baseDir()).thenReturn(baseDirFile);
+    Mockito.when(baseDir.toAbsolutePath()).thenReturn(baseDir);
+    Mockito.when(baseDir.normalize()).thenReturn(baseDir);
+    Mockito.when(baseDir.resolve(Mockito.any(Path.class))).thenReturn(manifestPath);
+    Mockito.when(manifestPath.normalize()).thenReturn(manifestPath);
+    Mockito.when(manifestPath.endsWith("Cargo.toml")).thenReturn(true);
+    Mockito.when(manifestPath.getParent()).thenReturn(null);
+
+    var diagnostic = diagnostic("Cargo.toml", "src/main.rs");
+
+    assertThatThrownBy(() -> ClippyUtils.resolveInputFile(diagnostic, context))
+      .isInstanceOf(ClippyImportException.class)
+      .hasMessage("Invalid manifest path: Cargo.toml");
+  }
+
+  @Test
+  void resolveInputFileWithNullFilePathThrows() throws IOException {
+    var baseDir = Files.createDirectories(temp.resolve("project"));
+    var context = SensorContextTester.create(baseDir);
+    var diagnostic = diagnosticWithSpans(baseDir.resolve("Cargo.toml").toString(), List.of(new ClippySpan(null, 1, 1, 1, 2)));
+
+    assertThatThrownBy(() -> ClippyUtils.resolveInputFile(diagnostic, context))
+      .isInstanceOf(ClippyImportException.class)
+      .hasMessage("Clippy diagnostic 'clippy::some_lint' has no file path");
+  }
+
+  @Test
+  void resolveInputFileWithBlankFilePathThrows() throws IOException {
+    var baseDir = Files.createDirectories(temp.resolve("project"));
+    var context = SensorContextTester.create(baseDir);
+    var diagnostic = diagnosticWithSpans(baseDir.resolve("Cargo.toml").toString(), List.of(new ClippySpan("   ", 1, 1, 1, 2)));
+
+    assertThatThrownBy(() -> ClippyUtils.resolveInputFile(diagnostic, context))
+      .isInstanceOf(ClippyImportException.class)
+      .hasMessage("Clippy diagnostic 'clippy::some_lint' has no file path");
+  }
+
+  @Test
+  void resolveInputFileWithNullSpansThrows() throws IOException {
+    var baseDir = Files.createDirectories(temp.resolve("project"));
+    var context = SensorContextTester.create(baseDir);
+    var diagnostic = diagnosticWithSpans(baseDir.resolve("Cargo.toml").toString(), null);
+
+    assertThatThrownBy(() -> ClippyUtils.resolveInputFile(diagnostic, context))
+      .isInstanceOf(ClippyImportException.class)
+      .hasMessage("Clippy diagnostic 'clippy::some_lint' has no location spans");
+  }
+
   private static InputFile inputFile(Path baseDir, String relativePath, String contents) {
     return TestInputFileBuilder.create("module", relativePath)
       .setModuleBaseDir(baseDir)
@@ -233,11 +297,15 @@ class ClippyUtilsTest {
   }
 
   private static ClippyDiagnostic diagnostic(String manifestPath, String fileName) {
+    return diagnosticWithSpans(manifestPath, List.of(new ClippySpan(fileName, 1, 1, 1, 2)));
+  }
+
+  private static ClippyDiagnostic diagnosticWithSpans(String manifestPath, List<ClippySpan> spans) {
     return new ClippyDiagnostic(
       manifestPath,
       new ClippyMessage(
         new ClippyCode("clippy::some_lint"),
         "message",
-        List.of(new ClippySpan(fileName, 1, 1, 1, 2))));
+        spans));
   }
 }


### PR DESCRIPTION
## Summary

This PR surfaces user-actionable Clippy report import failures as analysis warnings while keeping unknown rules log-only.

It adds warning handling for:
- missing Clippy report files
- unreadable or invalid Clippy reports
- diagnostics pointing to files outside the analyzed project
- malformed or otherwise non-importable diagnostics

Epic: SKUNK-1221
Related to: RUST-118

## Validation

Focused test coverage was added for the new warning behavior and de-duplication in `ClippyReportSensorTest`.
