### PR TITLE
RUST-121 Fix Clippy metadata update for commented lints

### DIFF
--- a/.github/workflows/update-clippy-metadata.yml
+++ b/.github/workflows/update-clippy-metadata.yml
@@ -181,7 +181,7 @@ jobs:
           RELEASE_TAG: ${{ steps.release_check.outputs.release_tag }}
           VAULT_OUTPUT: ${{ steps.secrets.outputs.vault }}
         run: |
-          GH_TOKEN="$(python3 -c 'import json, os; print(json.loads(os.environ["VAULT_OUTPUT"])["GITHUB_TOKEN"])')"
+          export GH_TOKEN="$(python3 -c 'import json, os; print(json.loads(os.environ["VAULT_OUTPUT"])["GITHUB_TOKEN"])')"
           BRANCH_NAME="automation/update-clippy-metadata-${RELEASE_TAG//[^A-Za-z0-9._-]/-}"
           TITLE="Draft: Update Clippy metadata for Rust ${RELEASE_TAG}"
           cp /tmp/clippy-step-summary.md /tmp/clippy-pr-body.md

--- a/.github/workflows/update-clippy-metadata.yml
+++ b/.github/workflows/update-clippy-metadata.yml
@@ -174,7 +174,8 @@ jobs:
             sonar-rust-plugin/src/main/resources/org/sonar/l10n/rust/rules/clippy/rules.json \
             sonar-rust-plugin/src/main/resources/org/sonar/l10n/rust/rules/clippy/upstream.json
           git commit -m "Update Clippy metadata for Rust ${RELEASE_TAG}"
-          git push --force-with-lease "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${BRANCH_NAME}"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push --force-with-lease origin "HEAD:${BRANCH_NAME}"
 
       - name: Create or update draft PR
         if: steps.release_check.outputs.needs_update == 'true' && steps.git_diff.outputs.has_changes == 'true' && inputs.dry_run != true

--- a/.github/workflows/update-clippy-metadata.yml
+++ b/.github/workflows/update-clippy-metadata.yml
@@ -149,53 +149,13 @@ jobs:
           PY
           cat /tmp/clippy-step-summary.md >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Fetch GitHub token for PR creation
-        if: steps.release_check.outputs.needs_update == 'true' && steps.git_diff.outputs.has_changes == 'true' && inputs.dry_run != true
-        id: secrets
-        uses: SonarSource/vault-action-wrapper@v3
-        with:
-          secrets: |
-            development/github/token/{REPO_OWNER_NAME_DASH}-jira token | GITHUB_TOKEN;
-
-      - name: Commit and push update branch
-        if: steps.release_check.outputs.needs_update == 'true' && steps.git_diff.outputs.has_changes == 'true' && inputs.dry_run != true
-        env:
-          RELEASE_TAG: ${{ steps.release_check.outputs.release_tag }}
-          VAULT_OUTPUT: ${{ steps.secrets.outputs.vault }}
-        run: |
-          GH_TOKEN="$(python3 -c 'import json, os; print(json.loads(os.environ["VAULT_OUTPUT"])["GITHUB_TOKEN"])')"
-          BRANCH_NAME="automation/update-clippy-metadata-${RELEASE_TAG//[^A-Za-z0-9._-]/-}"
-          git config user.name "sonarsource-bot"
-          git config user.email "infra@sonarsource.com"
-          git checkout -B "$BRANCH_NAME"
-          git fetch origin "refs/heads/${BRANCH_NAME}:refs/remotes/origin/${BRANCH_NAME}" || true
-          git add \
-            sonar-rust-plugin/src/main/resources/org/sonar/l10n/rust/rules/clippy/metadata.json \
-            sonar-rust-plugin/src/main/resources/org/sonar/l10n/rust/rules/clippy/rules.json \
-            sonar-rust-plugin/src/main/resources/org/sonar/l10n/rust/rules/clippy/upstream.json
-          git commit -m "Update Clippy metadata for Rust ${RELEASE_TAG}"
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git push --force-with-lease origin "HEAD:${BRANCH_NAME}"
-
       - name: Create or update draft PR
         if: steps.release_check.outputs.needs_update == 'true' && steps.git_diff.outputs.has_changes == 'true' && inputs.dry_run != true
-        env:
-          RELEASE_TAG: ${{ steps.release_check.outputs.release_tag }}
-          VAULT_OUTPUT: ${{ steps.secrets.outputs.vault }}
-        run: |
-          export GH_TOKEN="$(python3 -c 'import json, os; print(json.loads(os.environ["VAULT_OUTPUT"])["GITHUB_TOKEN"])')"
-          BRANCH_NAME="automation/update-clippy-metadata-${RELEASE_TAG//[^A-Za-z0-9._-]/-}"
-          TITLE="Draft: Update Clippy metadata for Rust ${RELEASE_TAG}"
-          cp /tmp/clippy-step-summary.md /tmp/clippy-pr-body.md
-
-          PR_NUMBER="$(gh pr list --head "$BRANCH_NAME" --base master --json number --jq '.[0].number')"
-          if [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "null" ]; then
-            gh pr edit "$PR_NUMBER" --title "$TITLE" --body-file /tmp/clippy-pr-body.md
-          else
-            gh pr create \
-              --base master \
-              --head "$BRANCH_NAME" \
-              --title "$TITLE" \
-              --body-file /tmp/clippy-pr-body.md \
-              --draft
-          fi
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
+        with:
+          commit-message: Update Clippy metadata for Rust ${{ steps.release_check.outputs.release_tag }}
+          title: Update Clippy metadata for Rust ${{ steps.release_check.outputs.release_tag }}
+          branch: automation/update-clippy-metadata-${{ steps.release_check.outputs.release_tag }}
+          base: master
+          body-path: /tmp/clippy-step-summary.md
+          draft: true

--- a/.github/workflows/update-clippy-metadata.yml
+++ b/.github/workflows/update-clippy-metadata.yml
@@ -168,6 +168,7 @@ jobs:
           git config user.name "sonarsource-bot"
           git config user.email "infra@sonarsource.com"
           git checkout -B "$BRANCH_NAME"
+          git fetch origin "refs/heads/${BRANCH_NAME}:refs/remotes/origin/${BRANCH_NAME}" || true
           git add \
             sonar-rust-plugin/src/main/resources/org/sonar/l10n/rust/rules/clippy/metadata.json \
             sonar-rust-plugin/src/main/resources/org/sonar/l10n/rust/rules/clippy/rules.json \

--- a/.github/workflows/update-clippy-metadata.yml
+++ b/.github/workflows/update-clippy-metadata.yml
@@ -110,44 +110,9 @@ jobs:
       - name: Write workflow summary
         if: steps.release_check.outputs.needs_update == 'true'
         run: |
-          python3 - <<'PY'
-          import json
-          from pathlib import Path
-
-          summary = json.loads(Path("/tmp/clippy-update-summary.json").read_text())
-          lines = [
-              "## Clippy metadata update",
-              "",
-              f"- Rust release: `{summary['rust_release_tag']}`",
-              f"- Published at: `{summary['rust_release_published_at']}`",
-              f"- metadata.json entries: `{summary['metadata_count_before']}` -> `{summary['metadata_count_after']}`",
-              f"- rules.json entries: `{summary['rules_count_before']}` -> `{summary['rules_count_after']}`",
-              f"- rules without rule key: `{len(summary['rules_without_rule_key'])}`",
-          ]
-
-          if summary["new_upstream_lints_without_mapping"]:
-              lines.extend(
-                  [
-                      "",
-                      "### New upstream lints without Sonar mapping",
-                      "",
-                  ]
-              )
-              lines.extend(f"- `{lint}`" for lint in summary["new_upstream_lints_without_mapping"])
-
-          if summary["new_upstream_lints"]:
-              lines.extend(
-                  [
-                      "",
-                      "### New upstream lints",
-                      "",
-                  ]
-              )
-              lines.extend(f"- `{lint}`" for lint in summary["new_upstream_lints"])
-
-          Path("/tmp/clippy-step-summary.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
-          PY
-          cat /tmp/clippy-step-summary.md >> "$GITHUB_STEP_SUMMARY"
+          python3 tools/clippy-metadata/workflow_summary.py \
+            --summary-file /tmp/clippy-update-summary.json \
+            | tee /tmp/clippy-step-summary.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create or update draft PR
         if: steps.release_check.outputs.needs_update == 'true' && steps.git_diff.outputs.has_changes == 'true' && inputs.dry_run != true

--- a/.github/workflows/update-clippy-metadata.yml
+++ b/.github/workflows/update-clippy-metadata.yml
@@ -162,9 +162,10 @@ jobs:
       - name: Commit and push update branch
         if: steps.release_check.outputs.needs_update == 'true' && steps.git_diff.outputs.has_changes == 'true' && inputs.dry_run != true
         env:
-          GH_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.release_check.outputs.release_tag }}
+          VAULT_OUTPUT: ${{ steps.secrets.outputs.vault }}
         run: |
+          GH_TOKEN="$(python3 -c 'import json, os; print(json.loads(os.environ["VAULT_OUTPUT"])["GITHUB_TOKEN"])')"
           BRANCH_NAME="automation/update-clippy-metadata-${RELEASE_TAG//[^A-Za-z0-9._-]/-}"
           git config user.name "sonarsource-bot"
           git config user.email "infra@sonarsource.com"
@@ -179,9 +180,10 @@ jobs:
       - name: Create or update draft PR
         if: steps.release_check.outputs.needs_update == 'true' && steps.git_diff.outputs.has_changes == 'true' && inputs.dry_run != true
         env:
-          GH_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.release_check.outputs.release_tag }}
+          VAULT_OUTPUT: ${{ steps.secrets.outputs.vault }}
         run: |
+          GH_TOKEN="$(python3 -c 'import json, os; print(json.loads(os.environ["VAULT_OUTPUT"])["GITHUB_TOKEN"])')"
           BRANCH_NAME="automation/update-clippy-metadata-${RELEASE_TAG//[^A-Za-z0-9._-]/-}"
           TITLE="Draft: Update Clippy metadata for Rust ${RELEASE_TAG}"
           cp /tmp/clippy-step-summary.md /tmp/clippy-pr-body.md

--- a/.github/workflows/update-clippy-metadata.yml
+++ b/.github/workflows/update-clippy-metadata.yml
@@ -32,8 +32,6 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: master
 
       - name: Check whether Rust has a newer release
         id: release_check

--- a/tools/clippy-metadata/clippy_metadata.py
+++ b/tools/clippy-metadata/clippy_metadata.py
@@ -160,6 +160,36 @@ def skip_block_comment(source: str, index: int) -> int:
     raise ValueError("unterminated block comment while parsing macro invocation")
 
 
+def strip_comments(source: str) -> str:
+    parts: list[str] = []
+    index = 0
+
+    while index < len(source):
+        if source.startswith("//", index):
+            index = skip_line_comment(source, index)
+            parts.append("\n")
+            continue
+        if source.startswith("/*", index):
+            index = skip_block_comment(source, index)
+            parts.append(" ")
+            continue
+        if source[index] == '"':
+            string_end = skip_string(source, index)
+            parts.append(source[index:string_end])
+            index = string_end
+            continue
+        raw_end = skip_raw_string(source, index)
+        if raw_end is not None:
+            parts.append(source[index:raw_end])
+            index = raw_end
+            continue
+
+        parts.append(source[index])
+        index += 1
+
+    return "".join(parts)
+
+
 def find_balanced_token_tree(source: str, start_index: int) -> int:
     opener = source[start_index]
     closer = OPEN_TO_CLOSE[opener]
@@ -207,7 +237,7 @@ def collect_macro_bodies(source: str) -> list[str]:
 
 
 def parse_declared_lint(body: str) -> dict[str, str] | None:
-    match = PUB_LINT_RE.search(body)
+    match = PUB_LINT_RE.search(strip_comments(body))
     if match is None:
         raise ValueError("could not find `pub <LINT>, <category>,` in declare_clippy_lint! body")
 

--- a/tools/clippy-metadata/tests/test_clippy_metadata.py
+++ b/tools/clippy-metadata/tests/test_clippy_metadata.py
@@ -128,6 +128,39 @@ class ClippyMetadataTest(unittest.TestCase):
 
             self.assertIn('"needs_update": true', stdout.getvalue())
 
+    def test_generate_metadata_allows_comments_between_lint_name_and_category(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            clippy_dir = Path(temp_dir)
+            (clippy_dir / "returns.rs").write_text(
+                """
+                declare_clippy_lint! {
+                    /// lint docs
+                    pub NEEDLESS_RETURN,
+                    // This lint requires some special handling in `check_final_expr` for `#[expect]`.
+                    // This handling needs to be updated if the group gets changed. This should also
+                    // be caught by tests.
+                    style,
+                    "message"
+                }
+                """,
+                encoding="utf-8",
+            )
+
+            metadata = clippy_metadata.generate_metadata(clippy_dir)
+
+            self.assertEqual(
+                clippy_metadata.json_text(metadata),
+                """[
+  {
+    "key": "needless_return",
+    "name": "needless_return",
+    "url": "https://rust-lang.github.io/rust-clippy/master/index.html#needless_return",
+    "description": "Clippy lint <code>needless_return</code>."
+  }
+]
+""",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/clippy-metadata/tests/test_workflow_summary.py
+++ b/tools/clippy-metadata/tests/test_workflow_summary.py
@@ -1,0 +1,67 @@
+# SonarQube Rust Plugin
+# Copyright (C) 2025-2026 SonarSource Sàrl
+# mailto:info AT sonarsource DOT com
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the Sonar Source-Available License for more details.
+#
+# You should have received a copy of the Sonar Source-Available License
+# along with this program; if not, see https://sonarsource.com/license/ssal/
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "workflow_summary.py"
+SPEC = importlib.util.spec_from_file_location("workflow_summary_impl", MODULE_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise ImportError(f"Unable to load workflow summary module from {MODULE_PATH}")
+
+workflow_summary = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(workflow_summary)
+
+
+class WorkflowSummaryTest(unittest.TestCase):
+    def test_build_summary_markdown_formats_expected_sections(self) -> None:
+        summary = {
+            "rust_release_tag": "1.94.0",
+            "rust_release_published_at": "2026-03-05T18:44:15Z",
+            "metadata_count_before": 770,
+            "metadata_count_after": 801,
+            "rules_count_before": 87,
+            "rules_count_after": 87,
+            "new_upstream_lints": ["foo_lint", "bar_lint"],
+            "new_upstream_lints_without_mapping": ["foo_lint"],
+            "rules_without_rule_key": ["clippy::deprecated_semver"],
+        }
+
+        self.assertEqual(
+            workflow_summary.build_summary_markdown(summary),
+            """## Clippy metadata update
+
+- Rust release: `1.94.0`
+- Published at: `2026-03-05T18:44:15Z`
+- metadata.json entries: `770` -> `801`
+- rules.json entries: `87` -> `87`
+- rules without rule key: `1`
+
+### New upstream lints without Sonar mapping
+
+- `foo_lint`
+
+### New upstream lints
+
+- `foo_lint`
+- `bar_lint`
+""",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/clippy-metadata/workflow_summary.py
+++ b/tools/clippy-metadata/workflow_summary.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# SonarQube Rust Plugin
+# Copyright (C) 2025-2026 SonarSource Sàrl
+# mailto:info AT sonarsource DOT com
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the Sonar Source-Available License for more details.
+#
+# You should have received a copy of the Sonar Source-Available License
+# along with this program; if not, see https://sonarsource.com/license/ssal/
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def build_summary_markdown(summary: dict[str, object]) -> str:
+    lines = [
+        "## Clippy metadata update",
+        "",
+        f"- Rust release: `{summary['rust_release_tag']}`",
+        f"- Published at: `{summary['rust_release_published_at']}`",
+        f"- metadata.json entries: `{summary['metadata_count_before']}` -> `{summary['metadata_count_after']}`",
+        f"- rules.json entries: `{summary['rules_count_before']}` -> `{summary['rules_count_after']}`",
+        f"- rules without rule key: `{len(summary['rules_without_rule_key'])}`",
+    ]
+
+    new_upstream_without_mapping = summary["new_upstream_lints_without_mapping"]
+    if new_upstream_without_mapping:
+        lines.extend(
+            [
+                "",
+                "### New upstream lints without Sonar mapping",
+                "",
+            ]
+        )
+        lines.extend(f"- `{lint}`" for lint in new_upstream_without_mapping)
+
+    new_upstream_lints = summary["new_upstream_lints"]
+    if new_upstream_lints:
+        lines.extend(
+            [
+                "",
+                "### New upstream lints",
+                "",
+            ]
+        )
+        lines.extend(f"- `{lint}`" for lint in new_upstream_lints)
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Render the Clippy metadata workflow step summary.")
+    parser.add_argument("--summary-file", type=Path, required=True)
+    args = parser.parse_args()
+
+    summary = json.loads(args.summary_file.read_text(encoding="utf-8"))
+    sys.stdout.write(build_summary_markdown(summary))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Epic: SKUNK-1221

## Initial Prompt
> Can you investigate https://github.com/SonarSource/sonar-rust/actions/runs/23421079342/job/68126055021?

## Summary
Fix the Clippy metadata updater so it handles the Rust 1.94.0 lint declaration shape that broke the scheduled automation, and make the workflow report the real failure more cleanly.

## Changes
- Strip Rust comments before extracting the lint name and category from `declare_clippy_lint!` bodies.
- Add a regression test for declarations with comments between the lint name and category.
- Parse the Vault token inside the workflow run steps instead of in YAML expressions so skipped secret-fetch steps do not trigger misleading template errors.

## Result of the workflow
- https://github.com/SonarSource/sonar-rust/pull/203
- https://github.com/SonarSource/sonar-rust/actions/runs/23443531868
