### PR TITLE
RUST-120 Add automated release workflow

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -1,0 +1,79 @@
+name: Automated Release
+on:
+  workflow_dispatch:
+    inputs:
+      short-description:
+        description: "Short description for the REL ticket"
+        required: true
+        type: string
+      rule-props-changed:
+        description: "Did any rule properties change in this release (see SC-4654)"
+        type: boolean
+        default: false
+      sqc-integration:
+        description: "Integrate into SQC"
+        type: boolean
+        default: true
+      sqs-integration:
+        description: "Integrate into SQS"
+        type: boolean
+        default: true
+      branch:
+        description: "Branch from which to do the release"
+        required: true
+        default: "master"
+        type: string
+      pm_email:
+        description: "PM email for the release workflow"
+        required: true
+        type: string
+      new-version:
+        description: "New version to release (without -SNAPSHOT; if left empty, the current minor version will be auto-incremented)"
+        required: false
+        type: string
+      dry-run:
+        description: "Dry-run mode: uses Jira sandbox and creates draft releases"
+        type: boolean
+        default: true
+
+jobs:
+  release:
+    name: Release
+    uses: SonarSource/release-github-actions/.github/workflows/automated-release.yml@v1
+    permissions:
+      statuses: read
+      id-token: write
+      contents: write
+      actions: write
+      pull-requests: write
+    with:
+      project-name: "SonarRust"
+      plugin-name: "rust"
+      release-automation-secret-name: "sonar-rust-release-automation"
+      jira-project-key: "RUST"
+      rule-props-changed: ${{ github.event.inputs.rule-props-changed == 'true' }}
+      short-description: ${{ github.event.inputs.short-description }}
+      new-version: ${{ github.event.inputs.new-version }}
+      sqc-integration: ${{ github.event.inputs.sqc-integration == 'true' }}
+      sqs-integration: ${{ github.event.inputs.sqs-integration == 'true' }}
+      create-slvs-ticket: false
+      create-slvscode-ticket: false
+      create-sle-ticket: false
+      create-sli-ticket: false
+      branch: ${{ github.event.inputs.branch }}
+      pm-email: ${{ github.event.inputs.pm_email }}
+      slack-channel: "squad-rust"
+      verbose: true
+      use-jira-sandbox: ${{ github.event.inputs.dry-run == 'true' }}
+      is-draft-release: ${{ github.event.inputs.dry-run == 'true' }}
+
+  bump_versions:
+    name: Bump versions
+    needs: release
+    uses: ./.github/workflows/bump-version.yml
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
+    with:
+      version: ${{ needs.release.outputs.new-version }}

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,49 @@
+name: Bump version
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: The new version (without -SNAPSHOT suffix)
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: The new version (without -SNAPSHOT suffix)
+        required: true
+        type: string
+
+jobs:
+  bump-version:
+    runs-on: github-ubuntu-latest-s
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
+        with:
+          version: 2026.2.7
+          mise_toml: |
+            [tools]
+            rust = "1.91.1"
+      - name: Update version files
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          snapshot_version="${VERSION}-SNAPSHOT"
+          sed -i "s/^version=.*-SNAPSHOT$/version=${snapshot_version}/" gradle.properties
+          sed -i "s/^version=.*-SNAPSHOT$/version=${snapshot_version}/" sonar-rust-plugin/gradle.properties
+
+          sed -i "s/^version = \".*\"$/version = \"${VERSION}\"/" "analyzer/Cargo.toml"
+      - name: Update Cargo.lock
+        run: cargo generate-lockfile --manifest-path analyzer/Cargo.toml
+      - uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
+        with:
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          commit-message: Prepare next development iteration
+          title: Bump version to ${{ inputs.version }}
+          branch: bot/bump-project-version
+          branch-suffix: timestamp
+          base: master
+          reviewers: ${{ github.actor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,21 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        description: "Release version tag (e.g., 1.2.3). Used when triggering manually instead of via release event."
+        required: true
+      releaseId:
+        type: string
+        description: "GitHub release ID. Used when triggering manually instead of via release event."
+        required: true
+      dryRun:
+        type: boolean
+        description: Flag to enable the dry-run execution
+        default: false
+        required: false
 
 env:
   PYTHONUNBUFFERED: 1
@@ -18,3 +33,6 @@ jobs:
       publishToBinaries: true
       mavenCentralSync: true
       slackChannel: squad-rust
+      version: ${{ inputs.version || github.event.release.tag_name }}
+      releaseId: ${{ inputs.releaseId || github.event.release.id }}
+      dryRun: ${{ inputs.dryRun == true }}


### PR DESCRIPTION
## Summary
Added the GitHub workflows needed to run the shared automated release process for SonarRust and to open the follow-up version bump pull request for the next development iteration.

## Changes
- added `.github/workflows/automated-release.yml` to expose the manual release inputs used by the shared release automation, including the PM email, dry-run mode, branch selection, and SQC/SQS integration toggles
- added `.github/workflows/bump-version.yml` to update Gradle and Cargo version files, regenerate `analyzer/Cargo.lock`, and open the next-iteration bump pull request automatically
- extended `.github/workflows/release.yml` with `workflow_dispatch` inputs so the publish workflow can also be triggered manually with a version, release ID, and dry-run flag