### PR TITLE
RUST-123 Align repo license headers with dateless template

### DIFF
--- a/analyzer/build.gradle.kts
+++ b/analyzer/build.gradle.kts
@@ -132,30 +132,7 @@ task<Exec>("checkRustFormat") {
 tasks.register("checkRustLicense") {
   description = "Checks Rust code license headers."
   group = "Verification"
-
-  fun checkLicenseHeader(file: File, expectedHeader: String): Boolean {
-    val fileContent = file.readText().trimStart()
-    return fileContent.startsWith(expectedHeader)
-  }
-
-  val rustFiles = fileTree("src/") {
-    include("**/*.rs")
-  }.toList()
-
-  doLast {
-    val licenseHeaderFile = file("${project.rootDir}/license-header.txt")
-    if (!licenseHeaderFile.exists()) {
-      throw GradleException("License header file not found: ${licenseHeaderFile.path}")
-    }
-
-    val expectedHeader = licenseHeaderFile.readText().trim()
-
-    val headerMismatches = rustFiles.filter { !checkLicenseHeader(it, expectedHeader) }
-    if (!headerMismatches.isEmpty()) {
-      headerMismatches.forEach { println("Missing or incorrect license header in: ${it.path}") }
-      throw GradleException("Some Rust files are missing the correct license header.")
-    }
-  }
+  dependsOn(rootProject.tasks.named("checkLicenseHeaders"))
 }
 
 task<Exec>("coverageRust") {

--- a/analyzer/src/analyze.rs
+++ b/analyzer/src/analyze.rs
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/analyzer/src/analyze.rs
+++ b/analyzer/src/analyze.rs
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/analyzer/src/issue.rs
+++ b/analyzer/src/issue.rs
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/analyzer/src/issue.rs
+++ b/analyzer/src/issue.rs
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/analyzer/src/main.rs
+++ b/analyzer/src/main.rs
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/analyzer/src/main.rs
+++ b/analyzer/src/main.rs
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/analyzer/src/rules/cognitive_complexity_check.rs
+++ b/analyzer/src/rules/cognitive_complexity_check.rs
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/analyzer/src/rules/cognitive_complexity_check.rs
+++ b/analyzer/src/rules/cognitive_complexity_check.rs
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/analyzer/src/rules/parsing_error_check.rs
+++ b/analyzer/src/rules/parsing_error_check.rs
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/analyzer/src/rules/parsing_error_check.rs
+++ b/analyzer/src/rules/parsing_error_check.rs
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/analyzer/src/rules/rule.rs
+++ b/analyzer/src/rules/rule.rs
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/analyzer/src/rules/rule.rs
+++ b/analyzer/src/rules/rule.rs
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/analyzer/src/tree.rs
+++ b/analyzer/src/tree.rs
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/analyzer/src/tree.rs
+++ b/analyzer/src/tree.rs
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/analyzer/src/visitors/cognitive_complexity.rs
+++ b/analyzer/src/visitors/cognitive_complexity.rs
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/analyzer/src/visitors/cognitive_complexity.rs
+++ b/analyzer/src/visitors/cognitive_complexity.rs
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/analyzer/src/visitors/cpd.rs
+++ b/analyzer/src/visitors/cpd.rs
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/analyzer/src/visitors/cpd.rs
+++ b/analyzer/src/visitors/cpd.rs
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/analyzer/src/visitors/cyclomatic_complexity.rs
+++ b/analyzer/src/visitors/cyclomatic_complexity.rs
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/analyzer/src/visitors/cyclomatic_complexity.rs
+++ b/analyzer/src/visitors/cyclomatic_complexity.rs
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/analyzer/src/visitors/highlight.rs
+++ b/analyzer/src/visitors/highlight.rs
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/analyzer/src/visitors/highlight.rs
+++ b/analyzer/src/visitors/highlight.rs
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/analyzer/src/visitors/metrics.rs
+++ b/analyzer/src/visitors/metrics.rs
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/analyzer/src/visitors/metrics.rs
+++ b/analyzer/src/visitors/metrics.rs
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.jfrog.gradle.plugin.artifactory.dsl.ArtifactoryPluginConvention
 
 plugins {
+  base
   id("org.sonarqube") version "7.2.3.7755"
   id("com.jfrog.artifactory") version "6.0.4"
 }
@@ -27,6 +28,48 @@ repositories {
     }
   mavenLocal()
   mavenCentral()
+}
+
+val checkLicenseHeaders = tasks.register("checkLicenseHeaders") {
+  description = "Checks repo-authored source file license headers."
+  group = "Verification"
+
+  val licenseHeaderFile = rootProject.file("license-header.txt")
+  val sourceFiles = files(
+    fileTree("analyzer/src") {
+      include("**/*.rs")
+    },
+    fileTree("sonar-rust-plugin/src") {
+      include("**/*.java")
+    },
+    fileTree("e2e/src") {
+      include("**/*.java")
+    },
+    fileTree("buildSrc/src/main/kotlin") {
+      include("**/*.kt", "**/*.kts")
+    }
+  )
+
+  inputs.file(licenseHeaderFile)
+  inputs.files(sourceFiles)
+
+  doLast {
+    val expectedHeader = licenseHeaderFile.readText().trim()
+    val headerMismatches = sourceFiles.files.filter { file ->
+      !file.readText().trimStart().startsWith(expectedHeader)
+    }
+
+    if (headerMismatches.isNotEmpty()) {
+      headerMismatches.forEach { println("Missing or incorrect license header in: ${it.path}") }
+      throw GradleException("Some source files are missing the correct license header.")
+    }
+  }
+}
+
+subprojects {
+  tasks.matching { it.name == "check" }.configureEach {
+    dependsOn(checkLicenseHeaders)
+  }
 }
 
 sonar {

--- a/buildSrc/src/main/kotlin/license-file-generator.gradle.kts
+++ b/buildSrc/src/main/kotlin/license-file-generator.gradle.kts
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/buildSrc/src/main/kotlin/license-file-generator.gradle.kts
+++ b/buildSrc/src/main/kotlin/license-file-generator.gradle.kts
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/buildSrc/src/main/kotlin/org/sonarsource/rust/gradle/AnalyzerLicensingPackagingRenderer.kt
+++ b/buildSrc/src/main/kotlin/org/sonarsource/rust/gradle/AnalyzerLicensingPackagingRenderer.kt
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/buildSrc/src/main/kotlin/org/sonarsource/rust/gradle/AnalyzerLicensingPackagingRenderer.kt
+++ b/buildSrc/src/main/kotlin/org/sonarsource/rust/gradle/AnalyzerLicensingPackagingRenderer.kt
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/buildSrc/src/main/kotlin/org/sonarsource/rust/gradle/LicenseGenerationUtils.kt
+++ b/buildSrc/src/main/kotlin/org/sonarsource/rust/gradle/LicenseGenerationUtils.kt
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/buildSrc/src/main/kotlin/org/sonarsource/rust/gradle/LicenseGenerationUtils.kt
+++ b/buildSrc/src/main/kotlin/org/sonarsource/rust/gradle/LicenseGenerationUtils.kt
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/buildSrc/src/main/kotlin/rust-license-file-generator.gradle.kts
+++ b/buildSrc/src/main/kotlin/rust-license-file-generator.gradle.kts
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/buildSrc/src/main/kotlin/rust-license-file-generator.gradle.kts
+++ b/buildSrc/src/main/kotlin/rust-license-file-generator.gradle.kts
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/e2e/src/test/java/org/sonarsource/rust/e2e/ClippyReportTest.java
+++ b/e2e/src/test/java/org/sonarsource/rust/e2e/ClippyReportTest.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/e2e/src/test/java/org/sonarsource/rust/e2e/ClippyReportTest.java
+++ b/e2e/src/test/java/org/sonarsource/rust/e2e/ClippyReportTest.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (C) 2025-2026 SonarSource Sàrl
- * All rights reserved
+ * SonarQube Rust Plugin
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonarsource.rust.e2e;
 

--- a/e2e/src/test/java/org/sonarsource/rust/e2e/ClippyRunnerTest.java
+++ b/e2e/src/test/java/org/sonarsource/rust/e2e/ClippyRunnerTest.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/e2e/src/test/java/org/sonarsource/rust/e2e/ClippyRunnerTest.java
+++ b/e2e/src/test/java/org/sonarsource/rust/e2e/ClippyRunnerTest.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (C) 2025-2026 SonarSource Sàrl
- * All rights reserved
+ * SonarQube Rust Plugin
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonarsource.rust.e2e;
 

--- a/e2e/src/test/java/org/sonarsource/rust/e2e/CoverageTest.java
+++ b/e2e/src/test/java/org/sonarsource/rust/e2e/CoverageTest.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/e2e/src/test/java/org/sonarsource/rust/e2e/CoverageTest.java
+++ b/e2e/src/test/java/org/sonarsource/rust/e2e/CoverageTest.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (C) 2025-2026 SonarSource Sàrl
- * All rights reserved
+ * SonarQube Rust Plugin
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonarsource.rust.e2e;
 

--- a/e2e/src/test/java/org/sonarsource/rust/e2e/DuplicationTest.java
+++ b/e2e/src/test/java/org/sonarsource/rust/e2e/DuplicationTest.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/e2e/src/test/java/org/sonarsource/rust/e2e/DuplicationTest.java
+++ b/e2e/src/test/java/org/sonarsource/rust/e2e/DuplicationTest.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (C) 2025-2026 SonarSource Sàrl
- * All rights reserved
+ * SonarQube Rust Plugin
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonarsource.rust.e2e;
 

--- a/e2e/src/test/java/org/sonarsource/rust/e2e/MetricsTest.java
+++ b/e2e/src/test/java/org/sonarsource/rust/e2e/MetricsTest.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/e2e/src/test/java/org/sonarsource/rust/e2e/MetricsTest.java
+++ b/e2e/src/test/java/org/sonarsource/rust/e2e/MetricsTest.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (C) 2025-2026 SonarSource Sàrl
- * All rights reserved
+ * SonarQube Rust Plugin
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonarsource.rust.e2e;
 

--- a/e2e/src/test/java/org/sonarsource/rust/e2e/OrchestratorHelper.java
+++ b/e2e/src/test/java/org/sonarsource/rust/e2e/OrchestratorHelper.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/e2e/src/test/java/org/sonarsource/rust/e2e/OrchestratorHelper.java
+++ b/e2e/src/test/java/org/sonarsource/rust/e2e/OrchestratorHelper.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (C) 2025-2026 SonarSource Sàrl
- * All rights reserved
+ * SonarQube Rust Plugin
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonarsource.rust.e2e;
 

--- a/e2e/src/test/java/org/sonarsource/rust/e2e/ProjectLayoutTest.java
+++ b/e2e/src/test/java/org/sonarsource/rust/e2e/ProjectLayoutTest.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/e2e/src/test/java/org/sonarsource/rust/e2e/ProjectLayoutTest.java
+++ b/e2e/src/test/java/org/sonarsource/rust/e2e/ProjectLayoutTest.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (C) 2025-2026 SonarSource Sàrl
- * All rights reserved
+ * SonarQube Rust Plugin
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 package org.sonarsource.rust.e2e;
 

--- a/license-header.txt
+++ b/license-header.txt
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/license-header.txt
+++ b/license-header.txt
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/cargo/CargoManifestProvider.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/cargo/CargoManifestProvider.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/cargo/CargoManifestProvider.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/cargo/CargoManifestProvider.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/cargo/package-info.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/cargo/package-info.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (C) 2025-2026 SonarSource Sàrl
- * All rights reserved
+ * SonarQube Rust Plugin
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 @ParametersAreNonnullByDefault
 package org.sonarsource.rust.cargo;

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/cargo/package-info.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/cargo/package-info.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyDiagnostic.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyDiagnostic.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyDiagnostic.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyDiagnostic.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyImportException.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyImportException.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyImportException.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyImportException.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyPrerequisite.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyPrerequisite.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyPrerequisite.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyPrerequisite.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyReportSensor.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyReportSensor.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyReportSensor.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyReportSensor.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyRule.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyRule.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyRule.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyRule.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyRulesDefinition.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyRulesDefinition.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyRulesDefinition.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyRulesDefinition.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyRunner.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyRunner.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyRunner.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyRunner.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippySensor.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippySensor.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippySensor.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippySensor.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyUtils.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyUtils.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippyUtils.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/package-info.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/package-info.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (C) 2025-2026 SonarSource Sàrl
- * All rights reserved
+ * SonarQube Rust Plugin
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 @ParametersAreNonnullByDefault
 package org.sonarsource.rust.clippy;

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/package-info.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/package-info.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/common/FileLocator.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/common/FileLocator.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/common/FileLocator.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/common/FileLocator.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/common/ProcessWrapper.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/common/ProcessWrapper.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/common/ProcessWrapper.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/common/ProcessWrapper.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/common/ReportProvider.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/common/ReportProvider.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/common/ReportProvider.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/common/ReportProvider.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/common/StreamConsumer.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/common/StreamConsumer.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/common/StreamConsumer.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/common/StreamConsumer.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/common/package-info.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/common/package-info.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (C) 2025-2026 SonarSource Sàrl
- * All rights reserved
+ * SonarQube Rust Plugin
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 @ParametersAreNonnullByDefault
 package org.sonarsource.rust.common;

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/common/package-info.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/common/package-info.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/coverage/CoberturaParser.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/coverage/CoberturaParser.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/coverage/CoberturaParser.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/coverage/CoberturaParser.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/coverage/CoberturaSensor.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/coverage/CoberturaSensor.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/coverage/CoberturaSensor.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/coverage/CoberturaSensor.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/coverage/CodeCoverage.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/coverage/CodeCoverage.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/coverage/CodeCoverage.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/coverage/CodeCoverage.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/coverage/CoverageUtils.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/coverage/CoverageUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/coverage/CoverageUtils.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/coverage/CoverageUtils.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/coverage/LcovParser.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/coverage/LcovParser.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/coverage/LcovParser.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/coverage/LcovParser.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/coverage/LcovSensor.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/coverage/LcovSensor.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/coverage/LcovSensor.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/coverage/LcovSensor.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/coverage/package-info.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/coverage/package-info.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/coverage/package-info.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/coverage/package-info.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (C) 2025-2026 SonarSource Sàrl
- * All rights reserved
+ * SonarQube Rust Plugin
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 @ParametersAreNonnullByDefault
 package org.sonarsource.rust.coverage;

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/AnalysisWarningsWrapper.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/AnalysisWarningsWrapper.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/AnalysisWarningsWrapper.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/AnalysisWarningsWrapper.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/Analyzer.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/Analyzer.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/Analyzer.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/Analyzer.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/AnalyzerFactory.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/AnalyzerFactory.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/AnalyzerFactory.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/AnalyzerFactory.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/PlatformDetection.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/PlatformDetection.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/PlatformDetection.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/PlatformDetection.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/RustLanguage.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/RustLanguage.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/RustLanguage.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/RustLanguage.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/RustPlugin.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/RustPlugin.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/RustPlugin.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/RustPlugin.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/RustProfile.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/RustProfile.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/RustProfile.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/RustProfile.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/RustRulesDefinition.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/RustRulesDefinition.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/RustRulesDefinition.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/RustRulesDefinition.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/RustSensor.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/RustSensor.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/RustSensor.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/RustSensor.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/SystemWrapper.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/SystemWrapper.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/SystemWrapper.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/SystemWrapper.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/Telemetry.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/Telemetry.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/Telemetry.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/Telemetry.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/package-info.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/package-info.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (C) 2025-2026 SonarSource Sàrl
- * All rights reserved
+ * SonarQube Rust Plugin
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
  */
 @ParametersAreNonnullByDefault
 package org.sonarsource.rust.plugin;

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/package-info.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/package-info.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/TestAnalysisWarnigs.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/TestAnalysisWarnigs.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/TestAnalysisWarnigs.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/TestAnalysisWarnigs.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/cargo/CargoManifestProviderTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/cargo/CargoManifestProviderTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/cargo/CargoManifestProviderTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/cargo/CargoManifestProviderTest.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyPrerequisiteTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyPrerequisiteTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyPrerequisiteTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyPrerequisiteTest.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyReportSensorTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyReportSensorTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyReportSensorTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyReportSensorTest.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyRulesDefinitionTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyRulesDefinitionTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyRulesDefinitionTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyRulesDefinitionTest.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyRunnerTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyRunnerTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyRunnerTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyRunnerTest.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippySensorTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippySensorTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippySensorTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippySensorTest.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyUtilsTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyUtilsTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyUtilsTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/clippy/ClippyUtilsTest.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/cobertura/CoberturaParserTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/cobertura/CoberturaParserTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/cobertura/CoberturaParserTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/cobertura/CoberturaParserTest.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/cobertura/CoberturaSensorTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/cobertura/CoberturaSensorTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/cobertura/CoberturaSensorTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/cobertura/CoberturaSensorTest.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/common/FileLocatorTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/common/FileLocatorTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/common/FileLocatorTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/common/FileLocatorTest.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/common/ReportProviderTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/common/ReportProviderTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/common/ReportProviderTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/common/ReportProviderTest.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/common/StreamConsumerTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/common/StreamConsumerTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/common/StreamConsumerTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/common/StreamConsumerTest.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/coverage/CodeCoverageTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/coverage/CodeCoverageTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/coverage/CodeCoverageTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/coverage/CodeCoverageTest.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/coverage/LcovParserTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/coverage/LcovParserTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/coverage/LcovParserTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/coverage/LcovParserTest.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/coverage/LcovSensorTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/coverage/LcovSensorTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/coverage/LcovSensorTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/coverage/LcovSensorTest.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/AnalyzerFactoryTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/AnalyzerFactoryTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/AnalyzerFactoryTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/AnalyzerFactoryTest.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/AnalyzerTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/AnalyzerTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/AnalyzerTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/AnalyzerTest.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/PlatformDetectionTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/PlatformDetectionTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/PlatformDetectionTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/PlatformDetectionTest.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/RustLanguageTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/RustLanguageTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/RustLanguageTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/RustLanguageTest.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/RustPluginTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/RustPluginTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/RustPluginTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/RustPluginTest.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/RustRulesDefinitionTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/RustRulesDefinitionTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/RustRulesDefinitionTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/RustRulesDefinitionTest.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/RustSensorTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/RustSensorTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/RustSensorTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/RustSensorTest.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/TelemetryTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/TelemetryTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Rust Plugin
- * Copyright (C) 2025-2026 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/TelemetryTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/TelemetryTest.java
@@ -3,8 +3,8 @@
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of


### PR DESCRIPTION
Epic: SKUNK-1221

## Initial Prompt
> Somethine needs to be done in this repos about the licenses:
>
> [...]

`[...]` is the discuss post verbatim

## Summary
Align the repository with the dateless SSAL source header template and enforce that shared header across the repo in the standard Gradle verification path.

## Changes
- Update the shared license header template and rewrite repo-authored Java, Kotlin, and Rust source headers to the dateless form.
- Add a root Gradle license-header verification task and hook subproject `check` tasks into it.
- Reuse the shared check from `:analyzer:checkRustLicense` and normalize the old shorter header variants in `e2e` and `package-info.java` files.
