### PR TITLE
RUST-124 Use GitHub-hosted runner for automated release

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -62,6 +62,7 @@ jobs:
       create-sli-ticket: false
       branch: ${{ github.event.inputs.branch }}
       pm-email: ${{ github.event.inputs.pm_email }}
+      runner-environment: "github-ubuntu-latest-s"
       slack-channel: "squad-rust"
       verbose: true
       use-jira-sandbox: ${{ github.event.inputs.dry-run == 'true' }}


### PR DESCRIPTION
Epic: SKUNK-1221

## Initial Prompt
> automated-release.yml is trying to run on the wrong runner on GHA but I can understand why.
> See https://github.com/SonarSource/sonar-kotlin/blob/master/.github/workflows/AutomateRelease.yml for similar workflow that is running on the correct runner

## Summary
The automated release workflow was calling the shared reusable release workflow without overriding its default runner, which made it fall back to `sonar-m`. This change pins the reusable workflow to the GitHub-hosted Ubuntu runner already used elsewhere in this repository.

## Changes
- Set `runner-environment: "github-ubuntu-latest-s"` in the automated release workflow call.
- Kept the existing reusable workflow and release logic unchanged, only overriding the runner selection input.
