### PR TITLE
RUST-126 Enable release freeze and guard bump workflow

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -65,13 +65,13 @@ jobs:
       runner-environment: "github-ubuntu-latest-s"
       slack-channel: "squad-rust"
       verbose: true
-      freeze-branch: false
       use-jira-sandbox: ${{ github.event.inputs.dry-run == 'true' }}
       is-draft-release: ${{ github.event.inputs.dry-run == 'true' }}
 
   bump_versions:
     name: Bump versions
     needs: release
+    if: ${{ needs.release.outputs.new-version != '' }}
     uses: ./.github/workflows/bump-version.yml
     permissions:
       contents: write

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -27,6 +27,14 @@ jobs:
           mise_toml: |
             [tools]
             rust = "1.91.1"
+      - name: Validate version input
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [ -z "$VERSION" ]; then
+            echo "::error::Input 'version' is empty. The release workflow did not produce a next iteration version."
+            exit 1
+          fi
       - name: Update version files
         env:
           VERSION: ${{ inputs.version }}


### PR DESCRIPTION
Epic: SKUNK-1662

## Summary
Re-enable branch freezing in the automated release workflow for sonar-rust and harden the follow-up bump workflow so a missing next-iteration version does not corrupt version files. This depends on SonarSource/re-terraform-aws-vault#8855 being merged so the lock token is available.

## Changes
- remove the local override that disabled `freeze-branch` in the automated release workflow
- skip the top-level bump workflow when the release workflow does not output `new-version`
- validate the version input before editing files in the reusable bump workflow
- depend on SonarSource/re-terraform-aws-vault#8855 for the `SonarSource-sonar-rust-lock` token
