### PR TITLE
RUST-131 Prevent bump-version workflow from modifying mise.toml

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -46,6 +46,8 @@ jobs:
           sed -i "s/^version = \".*\"$/version = \"${VERSION}\"/" "analyzer/Cargo.toml"
       - name: Update Cargo.lock
         run: cargo generate-lockfile --manifest-path analyzer/Cargo.toml
+      - name: Restore tracked mise.toml
+        run: git restore --source=HEAD --staged --worktree mise.toml
       - uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>


### PR DESCRIPTION
Epic: SKUNK-1662

## Summary
Prevent the bump-version workflow from leaking a temporary mise configuration into the generated pull request.

## Changes
- add a restore step for tracked mise.toml after the lockfile refresh
- keep create-pull-request unconstrained so future versioned components do not require workflow maintenance
