### PR TITLE
RUST-132 Normalize Cargo version in bump workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -43,7 +43,13 @@ jobs:
           sed -i "s/^version=.*-SNAPSHOT$/version=${snapshot_version}/" gradle.properties
           sed -i "s/^version=.*-SNAPSHOT$/version=${snapshot_version}/" sonar-rust-plugin/gradle.properties
 
-          sed -i "s/^version = \".*\"$/version = \"${VERSION}\"/" "analyzer/Cargo.toml"
+          cargo_version="${VERSION}"
+          if [[ "${cargo_version}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            cargo_version="${cargo_version}.0"
+            echo "::notice::Normalizing Cargo version '${VERSION}' to '${cargo_version}'"
+          fi
+
+          sed -i "s/^version = \".*\"$/version = \"${cargo_version}\"/" "analyzer/Cargo.toml"
       - name: Update Cargo.lock
         run: cargo generate-lockfile --manifest-path analyzer/Cargo.toml
       - name: Restore tracked mise.toml


### PR DESCRIPTION
Epic: SKUNK-1662

## Initial Prompt
> This is failing because the version does not contains the PATCH number.
> Can you update the job so it handle adding the patch when not present when updating Cargo.toml file?

## Summary
Normalize the Cargo manifest version in the bump workflow when the release pipeline provides only a major/minor version.

## Changes
- append `.0` before updating `analyzer/Cargo.toml` when the incoming version matches `major.minor`
- emit a GitHub Actions notice when the workflow normalizes the Cargo version
