### PR TITLE
RUST-135 Revert "Pin dependencies (#221)"

### DIFF
--- a/.github/actions/orchestrator-cache/action.yml
+++ b/.github/actions/orchestrator-cache/action.yml
@@ -19,7 +19,7 @@ runs:
         mkdir -p "${{ github.workspace }}/orchestrator"
 
     - name: Restore and save orchestrator cache
-      uses: SonarSource/gh-action_cache@v1.4.4
+      uses: SonarSource/gh-action_cache@v1
       with:
         path: ${{ env.ORCHESTRATOR_HOME }}
         key: ${{ inputs.key-prefix }}-${{ env.ORCHESTRATOR_CACHE_MONTH }}-${{ github.run_id }}

--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -16,7 +16,7 @@ jobs:
         github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - id: secrets
-        uses: SonarSource/vault-action-wrapper@3.4.0
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/kv/data/jira user | JIRA_USER;

--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -17,7 +17,7 @@ jobs:
         && github.event.pull_request.user.login != 'renovate[bot]'
     steps:
       - id: secrets
-        uses: SonarSource/vault-action-wrapper@3.4.0
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/github/token/{REPO_OWNER_NAME_DASH}-jira token | GITHUB_TOKEN;

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - id: secrets
-        uses: SonarSource/vault-action-wrapper@3.4.0
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/github/token/{REPO_OWNER_NAME_DASH}-jira token | GITHUB_TOKEN;

--- a/.github/workflows/ShadowScans.yml
+++ b/.github/workflows/ShadowScans.yml
@@ -32,7 +32,7 @@ jobs:
           rustup target add x86_64-unknown-linux-musl
           cargo install cargo-llvm-cov cargo-about
       - name: SQC shadow scans
-        uses: SonarSource/ci-github-actions/build-gradle@1.3.34
+        uses: SonarSource/ci-github-actions/build-gradle@v1
         with:
           deploy: false
           deploy-pull-request: false
@@ -52,7 +52,7 @@ jobs:
       contents: write
     steps:
       - name: Run IRIS Analysis
-        uses: SonarSource/unified-dogfooding-actions/run-iris@1.0.0
+        uses: SonarSource/unified-dogfooding-actions/run-iris@v1
         with:
           primary_project_key: "SonarSource_sonar-rust"
           primary_platform: "Next" # Platform of the primary platform (Next, SQC-EU, SQC-US)

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -18,7 +18,7 @@ jobs:
             || github.event.review.state == 'approved')
     steps:
       - id: secrets
-        uses: SonarSource/vault-action-wrapper@3.4.0
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/kv/data/jira user | JIRA_USER;

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -39,7 +39,7 @@ on:
 jobs:
   release:
     name: Release
-    uses: SonarSource/release-github-actions/.github/workflows/automated-release.yml@1.5.4
+    uses: SonarSource/release-github-actions/.github/workflows/automated-release.yml@v1
     permissions:
       statuses: read
       id-token: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       # see https://xtranet-sonarsource.atlassian.net/wiki/spaces/Platform/pages/4412309510/MacOS+Runners+-+GitHub
       - name: Setup Cloudflare WARP
-        uses: SonarSource/gh-action_setup-cloudflare-warp@v1.0.7
+        uses: SonarSource/gh-action_setup-cloudflare-warp@v1
         id: warp
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
@@ -150,7 +150,7 @@ jobs:
           rustup component add llvm-tools rustfmt clippy
           rustup target add x86_64-unknown-linux-musl
           cargo install cargo-llvm-cov cargo-about
-      - uses: SonarSource/ci-github-actions/build-gradle@1.3.34
+      - uses: SonarSource/ci-github-actions/build-gradle@v1
         with:
           deploy: false
           deploy-pull-request: false
@@ -201,7 +201,7 @@ jobs:
         with:
           name: analyzer-x86_64-pc-windows-gnu
           path: analyzer/target/x86_64-pc-windows-gnu/release/      
-      - uses: SonarSource/ci-github-actions/build-gradle@1.3.34
+      - uses: SonarSource/ci-github-actions/build-gradle@v1
         with:
           deploy-pull-request: true
           gradle-args: "-PskipAnalyzerBuild --info --stacktrace"
@@ -226,11 +226,11 @@ jobs:
           version: 2025.7.12
       - name: Vault
         id: secrets
-        uses: SonarSource/vault-action-wrapper@3.4.0
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/github/token/licenses-ro token | GITHUB_TOKEN;
-      - uses: SonarSource/ci-github-actions/config-gradle@1.3.34
+      - uses: SonarSource/ci-github-actions/config-gradle@v1
       - name: Run E2E tests
         env:
           GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
@@ -256,7 +256,7 @@ jobs:
           version: 2025.7.12
       - name: Vault
         id: secrets
-        uses: SonarSource/vault-action-wrapper@3.4.0
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/github/token/licenses-ro token | GITHUB_TOKEN;
@@ -266,7 +266,7 @@ jobs:
           ./rustup-init.exe -y --default-host x86_64-pc-windows-msvc --default-toolchain stable --profile minimal
           $env:PATH += ";$env:USERPROFILE\.cargo\bin"
           rustup component add clippy
-      - uses: SonarSource/ci-github-actions/config-gradle@1.3.34
+      - uses: SonarSource/ci-github-actions/config-gradle@v1
       - name: Run E2E tests
         shell: bash
         env:
@@ -300,11 +300,11 @@ jobs:
           version: 2025.7.12
       - name: Vault
         id: secrets
-        uses: SonarSource/vault-action-wrapper@3.4.0
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/github/token/licenses-ro token | GITHUB_TOKEN;
-      - uses: SonarSource/ci-github-actions/config-gradle@1.3.34
+      - uses: SonarSource/ci-github-actions/config-gradle@v1
       - name: Run E2E tests in ARM64 container
         shell: bash
         env:
@@ -332,7 +332,7 @@ jobs:
     runs-on: github-ubuntu-latest-s
     steps:
       # https://github.com/SonarSource/release-github-actions/tree/master/notify-slack
-      - uses: SonarSource/release-github-actions/notify-slack@1.5.4
+      - uses: SonarSource/release-github-actions/notify-slack@v1
         with:
           project-name: "Sonar-Rust"
           icon: ":cyber-radish:"
@@ -353,6 +353,6 @@ jobs:
     permissions:
       id-token: write
     steps:      
-      - uses: SonarSource/ci-github-actions/promote@1.3.34
+      - uses: SonarSource/ci-github-actions/promote@v1
         with:
           promote-pull-request: true

--- a/.github/workflows/lock-branch.yaml
+++ b/.github/workflows/lock-branch.yaml
@@ -11,7 +11,7 @@ jobs:
       id-token: write
     steps:
       - id: secrets
-        uses: SonarSource/vault-action-wrapper@3.4.0
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/github/token/{REPO_OWNER_NAME_DASH}-lock token | lock_token;

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -9,4 +9,4 @@ jobs:
     permissions:
       actions: write
     steps:
-      - uses: SonarSource/ci-github-actions/pr_cleanup@1.3.34
+      - uses: SonarSource/ci-github-actions/pr_cleanup@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@6.8.0
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v6
     with:
       publishToBinaries: true
       mavenCentralSync: true


### PR DESCRIPTION
This reverts commit 889cb3538b444e0853151c8717cdfda3e1908694.

As these are internal dependencies, they don't bring security risks and not pinning as the advantage of automatically using new versions.