### PR TITLE
Pin cargo-about through mise for license report

### DIFF
--- a/.github/workflows/ShadowScans.yml
+++ b/.github/workflows/ShadowScans.yml
@@ -30,7 +30,7 @@ jobs:
           rustup default ${{ env.RUST_VERSION }}
           rustup component add llvm-tools rustfmt clippy
           rustup target add x86_64-unknown-linux-musl
-          cargo install cargo-llvm-cov cargo-about
+          cargo install cargo-llvm-cov
       - name: SQC shadow scans
         uses: SonarSource/ci-github-actions/build-gradle@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,7 +149,7 @@ jobs:
           rustup default ${{ env.RUST_VERSION }}
           rustup component add llvm-tools rustfmt clippy
           rustup target add x86_64-unknown-linux-musl
-          cargo install cargo-llvm-cov cargo-about
+          cargo install cargo-llvm-cov
       - uses: SonarSource/ci-github-actions/build-gradle@v1
         with:
           deploy: false

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Generated files are stored in `sonar-rust-plugin/src/main/resources/licenses/`.
 
 License files for Rust runtime dependencies are managed in the `analyzer` module using [cargo-about](https://github.com/EmbarkStudios/cargo-about):
 
-- **Prerequisite**: Install cargo-about with `cargo install cargo-about`
+- **Prerequisite**: Run `mise install` to install the pinned `cargo-about` tool version
 - **Generate licenses**: `./gradlew :analyzer:generateRustLicenseResources`
 - **Validate licenses**: `./gradlew :analyzer:validateRustLicenseFiles` (runs automatically with `check`)
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,3 @@
 [tools]
 java = "21"
+"cargo:cargo-about" = "0.8.4"


### PR DESCRIPTION
## Summary
Pin cargo-about in mise.toml so the jobs already using mise-action provide the tool needed by the Rust license report task.

## Verification
- Confirmed the failing jobs already run jdx/mise-action

Part of SKUNK-1662