### PR TITLE
RUST-136 Add missing gradle.lockfile for root project

### DIFF
--- a/gradle.lockfile
+++ b/gradle.lockfile
@@ -1,0 +1,4 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+empty=


### PR DESCRIPTION
- Root project has no resolvable configurations so Gradle never generates a lockfile for it
- SonarQube rule S8569 (`LockfileForJavaCheck`) checks for lockfile presence on any `build.gradle.kts` that is not a submodule, regardless of build file content
- Adding an empty lockfile satisfies the rule and unblocks the quality gate