### PR TITLE
Fix macOS Analyzers Build: add repox credentials

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
   macos_analyzers:
     runs-on: macos-latest
     name: macOS Analyzers Build
-    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/branch-') || startsWith(github.ref, 'refs/heads/dogfood-')
+    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/branch-') || startsWith(github.ref, 'refs/heads/dogfood-') || github.event_name == 'workflow_dispatch'
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           source $HOME/.cargo/env
           rustup target add x86_64-apple-darwin
+      - uses: SonarSource/ci-github-actions/config-gradle@v1
       - name: Build Rust analyzers
         run: |
           echo "org.gradle.daemon=false" >> "gradle.properties"


### PR DESCRIPTION
- Add `SonarSource/ci-github-actions/config-gradle@v1` to `macos_analyzers` job
- Without credentials, Gradle falls back to Gradle Plugin Portal and artifacts have different checksums than those recorded in `gradle/verification-metadata.xml` (repox normalizes POMs)
- Same fix already applied to `cross_platform_analyzers` in #226