### PR TITLE
RUST-140 Bump RUST_VERSION to 1.95.0 in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUST_VERSION: 1.91.1
+  RUST_VERSION: 1.95.0
 
 jobs:
   macos_analyzers:


### PR DESCRIPTION
- Bumps `RUST_VERSION` env var in `.github/workflows/build.yml` from 1.91.1 to 1.95.0 (current stable, released 2026-04-14).
- Aligns CI toolchain with Clippy metadata already updated for 1.95.0 in #220.