### PR TITLE
RUST-141 Disable pin/rollback updates for SonarSource GitHub Actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>SonarSource/renovate-config"
+    "github>SonarSource/renovate-config:languages-team"
   ],
   "enabledManagers": [
     "github-actions",

--- a/renovate.json
+++ b/renovate.json
@@ -100,6 +100,21 @@
       "groupSlug": "all-sonar-github-actions"
     },
     {
+      "description": "SonarSource GitHub actions do not need version pinning",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchPackageNames": [
+        "SonarSource/*",
+        "sonarsource/*"
+      ],
+      "matchUpdateTypes": [
+        "pin",
+        "rollback"
+      ],
+      "enabled": false
+    },
+    {
       "matchManagers": [
         "github-actions"
       ],


### PR DESCRIPTION
- Adds a \`packageRule\` to disable \`pin\` and \`rollback\` update types for \`SonarSource/*\` GitHub Actions
- Prevents Renovate from recreating PRs that replace \`@v3\` tags with exact versions
- Pattern from [SonarSource/renovate-config#122](https://github.com/SonarSource/renovate-config/pull/122)