### PR TITLE
CLP-33 Add additional message to the ToggleLockBranch workflow

### DIFF
--- a/.github/workflows/lock-branch.yaml
+++ b/.github/workflows/lock-branch.yaml
@@ -2,6 +2,10 @@ name: Toggle lock branch
 
 on:
   workflow_dispatch:    # Triggered manually from the GitHub UI / Actions
+    inputs:
+      additional-message:
+        description: 'Additional Slack message text'
+        required: false
 
 jobs:
   lock-branch:
@@ -20,4 +24,5 @@ jobs:
         with:
           github-token: ${{ fromJSON(steps.secrets.outputs.vault).lock_token }}
           slack-token: ${{ fromJSON(steps.secrets.outputs.vault).slack_api_token }}
-          slack-channel: squad-rust
+          additional-message: ${{ github.event.inputs.additional-message }}
+          slack-channel: squad-corelang-notifs

--- a/.github/workflows/lock-branch.yaml
+++ b/.github/workflows/lock-branch.yaml
@@ -25,4 +25,4 @@ jobs:
           github-token: ${{ fromJSON(steps.secrets.outputs.vault).lock_token }}
           slack-token: ${{ fromJSON(steps.secrets.outputs.vault).slack_api_token }}
           additional-message: ${{ github.event.inputs.additional-message }}
-          slack-channel: squad-corelang-notifs
+          slack-channel: core-languages-releases


### PR DESCRIPTION
Part of [CLP-13](https://sonarsource.atlassian.net/browse/CLP-13).

[CLP-13]: https://sonarsource.atlassian.net/browse/CLP-13?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

----
## Summary by Gitar

- **Workflow updates:**
  - Added an optional `additional-message` input field to the `ToggleLockBranch` workflow.
  - Updated the `lock-branch` job to pass the `additional-message` input to the action.
- **Configuration changes:**
  - Updated the Slack notification channel from `squad-rust` to `core-languages-releases`.

<sub>This will update automatically on new commits.</sub>