### PR TITLE
RUST-247 Add RustRulesRepository API to contribute rules to Sonar way

### DIFF
--- a/custom-rules-plugin/build.gradle.kts
+++ b/custom-rules-plugin/build.gradle.kts
@@ -1,0 +1,60 @@
+plugins {
+  id("java")
+  id("com.gradleup.shadow") version "9.4.2"
+}
+
+// Test-fixture plugin: a minimal SonarQube plugin that implements the
+// org.sonar.plugins.rust.api.RustRulesRepository extension point exposed by sonar-rust, used by the
+// e2e module to exercise that API independently of any other plugin. Not published or released.
+
+val sonarApiVersion = "13.2.0.3137"
+
+repositories {
+  val artifactoryUsername = System.getenv("ARTIFACTORY_PRIVATE_USERNAME") ?: project.findProperty("artifactoryUsername")
+  val artifactoryPassword = System.getenv("ARTIFACTORY_PRIVATE_PASSWORD") ?: project.findProperty("artifactoryPassword")
+  maven {
+    url = uri("https://repox.jfrog.io/repox/sonarsource")
+    if (artifactoryUsername is String && artifactoryPassword is String) {
+      credentials {
+        username = artifactoryUsername
+        password = artifactoryPassword
+      }
+    }
+  }
+  mavenCentral()
+}
+
+dependencies {
+  compileOnly("org.sonarsource.api.plugin:sonar-plugin-api:$sonarApiVersion")
+  // For the RustRulesRepository API only. At runtime SonarQube exposes that api package from the
+  // installed base plugin, so it is not bundled into this fixture's jar (compileOnly).
+  compileOnly(project(":sonar-rust-plugin"))
+}
+
+java {
+  toolchain {
+    languageVersion = JavaLanguageVersion.of(17)
+  }
+}
+
+sonarqube.isSkipProject = true
+
+tasks.jar {
+  enabled = false
+  dependsOn(tasks.shadowJar)
+  manifest {
+    attributes(
+      mapOf(
+        "Plugin-Key" to "customrust",
+        "Plugin-Name" to "Custom Rust Rules (test fixture)",
+        "Plugin-Version" to project.version,
+        "Plugin-Class" to "org.sonarsource.rust.custom.CustomRulesPlugin",
+        "Plugin-RequiredForLanguages" to "rust",
+      )
+    )
+  }
+}
+
+tasks.shadowJar {
+  archiveClassifier.set("")
+}

--- a/custom-rules-plugin/gradle.lockfile
+++ b/custom-rules-plugin/gradle.lockfile
@@ -1,0 +1,6 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.slf4j:slf4j-api:1.7.30=compileClasspath
+org.sonarsource.api.plugin:sonar-plugin-api:13.2.0.3137=compileClasspath
+empty=annotationProcessor,runtimeClasspath,shadow

--- a/custom-rules-plugin/src/main/java/org/sonarsource/rust/custom/CustomRulesDefinition.java
+++ b/custom-rules-plugin/src/main/java/org/sonarsource/rust/custom/CustomRulesDefinition.java
@@ -1,0 +1,51 @@
+/*
+ * SonarQube Rust Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.rust.custom;
+
+import org.sonar.api.server.rule.RulesDefinition;
+
+/**
+ * Declares the fixture plugin's rules in the {@code customrust} repository.
+ *
+ * <ul>
+ *   <li>{@link #OVERRIDING_RULE} reuses an id that the base {@code rust} repository also defines and
+ *   activates in "Sonar way", to exercise reconciliation (the contributed rule should supersede the
+ *   base one).</li>
+ *   <li>{@link #NEW_RULE} is a brand-new id only this plugin provides.</li>
+ * </ul>
+ */
+public class CustomRulesDefinition implements RulesDefinition {
+
+  static final String REPOSITORY = "customrust";
+  static final String LANGUAGE = "rust";
+  /** Also defined by the base {@code rust} repository and active in its "Sonar way". */
+  static final String OVERRIDING_RULE = "S3776";
+  /** Only defined by this plugin. */
+  static final String NEW_RULE = "S9999";
+
+  @Override
+  public void define(Context context) {
+    var repository = context.createRepository(REPOSITORY, LANGUAGE).setName("Custom Rust Rules");
+    repository.createRule(OVERRIDING_RULE)
+      .setName("Custom reimplementation of a base rule")
+      .setHtmlDescription("Reuses the id of a base <code>rust</code> rule to test reconciliation.");
+    repository.createRule(NEW_RULE)
+      .setName("Custom-only rule")
+      .setHtmlDescription("A rule that only the custom plugin provides.");
+    repository.done();
+  }
+}

--- a/custom-rules-plugin/src/main/java/org/sonarsource/rust/custom/CustomRulesPlugin.java
+++ b/custom-rules-plugin/src/main/java/org/sonarsource/rust/custom/CustomRulesPlugin.java
@@ -1,0 +1,34 @@
+/*
+ * SonarQube Rust Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.rust.custom;
+
+import org.sonar.api.Plugin;
+
+/**
+ * Entry point of a minimal test-fixture plugin used by the e2e module to exercise the
+ * {@link org.sonar.plugins.rust.api.RustRulesRepository} extension point exposed by sonar-rust,
+ * independently of any other plugin.
+ */
+public class CustomRulesPlugin implements Plugin {
+
+  @Override
+  public void define(Context context) {
+    context.addExtensions(
+      CustomRulesDefinition.class,
+      CustomRustRulesRepository.class);
+  }
+}

--- a/custom-rules-plugin/src/main/java/org/sonarsource/rust/custom/CustomRustRulesRepository.java
+++ b/custom-rules-plugin/src/main/java/org/sonarsource/rust/custom/CustomRustRulesRepository.java
@@ -1,0 +1,35 @@
+/*
+ * SonarQube Rust Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.rust.custom;
+
+import java.util.Collection;
+import java.util.List;
+import org.sonar.plugins.rust.api.RustRulesRepository;
+
+/**
+ * Contributes the fixture plugin's rules to the built-in "Sonar way" profile through the
+ * {@link RustRulesRepository} extension point exposed by the base sonar-rust plugin.
+ */
+public class CustomRustRulesRepository implements RustRulesRepository {
+
+  @Override
+  public Collection<String> ruleKeys() {
+    return List.of(
+      CustomRulesDefinition.REPOSITORY + ":" + CustomRulesDefinition.OVERRIDING_RULE,
+      CustomRulesDefinition.REPOSITORY + ":" + CustomRulesDefinition.NEW_RULE);
+  }
+}

--- a/e2e/build.gradle.kts
+++ b/e2e/build.gradle.kts
@@ -50,4 +50,12 @@ tasks.test {
     }
     useJUnitPlatform()
     systemProperty("pluginVersion", System.getProperty("pluginVersion", null))
+    if (project.hasProperty("e2e")) {
+        // RustRulesRepositoryApiTest installs the fixture plugin from its build output. Build it (and,
+        // for local runs, the base plugin jar the OrchestratorHelper picks up) before the ITs run.
+        dependsOn(":custom-rules-plugin:shadowJar")
+        if (System.getProperty("pluginVersion").isNullOrEmpty()) {
+            dependsOn(":sonar-rust-plugin:shadowJar")
+        }
+    }
 }

--- a/e2e/src/test/java/org/sonarsource/rust/e2e/OrchestratorHelper.java
+++ b/e2e/src/test/java/org/sonarsource/rust/e2e/OrchestratorHelper.java
@@ -34,23 +34,25 @@ public class OrchestratorHelper implements BeforeAllCallback,  ExtensionContext.
   private static final OrchestratorExtension orchestrator = createOrchestrator();
 
   public static OrchestratorExtension createOrchestrator() {
-    // The sonar-rust-plugin jar is retrieved from different locations depending on the environment.
-    // When running tests locally, the jar is retrieved from the local build output directory.
-    // When running tests on CI, the jar is retrieved from JFrog, where it was published during the CI build process.
-    Location pluginLocation;
-    var version = System.getProperty("pluginVersion");
-    if (version == null || version.isEmpty()) {
-      pluginLocation = FileLocation.byWildcardMavenFilename(new File("../sonar-rust-plugin/build/libs"), "sonar-rust-plugin-*.jar");
-    } else {
-      pluginLocation = MavenLocation.of("org.sonarsource.rust", "sonar-rust-plugin", version);
-    }
     return OrchestratorExtension.builderEnv()
       .setEdition(Edition.ENTERPRISE_LW)
       .activateLicense()
       .useDefaultAdminCredentialsForBuilds(true)
       .setSonarVersion(System.getProperty("sonar.runtimeVersion", "LATEST_RELEASE"))
-      .addPlugin(pluginLocation)
+      .addPlugin(basePluginLocation())
       .build();
+  }
+
+  /**
+   * Location of the sonar-rust-plugin jar. Locally it is taken from the build output directory; on
+   * CI it is resolved from JFrog by the version published during the build.
+   */
+  static Location basePluginLocation() {
+    var version = System.getProperty("pluginVersion");
+    if (version == null || version.isEmpty()) {
+      return FileLocation.byWildcardMavenFilename(new File("../sonar-rust-plugin/build/libs"), "sonar-rust-plugin-*.jar");
+    }
+    return MavenLocation.of("org.sonarsource.rust", "sonar-rust-plugin", version);
   }
 
   @Override

--- a/e2e/src/test/java/org/sonarsource/rust/e2e/RustRulesRepositoryApiTest.java
+++ b/e2e/src/test/java/org/sonarsource/rust/e2e/RustRulesRepositoryApiTest.java
@@ -17,21 +17,21 @@
 package org.sonarsource.rust.e2e;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.sonar.orchestrator.container.Edition;
 import com.sonar.orchestrator.container.Server;
 import com.sonar.orchestrator.junit5.OrchestratorExtension;
 import com.sonar.orchestrator.locator.FileLocation;
 import java.io.File;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.sonarqube.ws.Rules;
 import org.sonarqube.ws.client.HttpConnector;
 import org.sonarqube.ws.client.WsClient;
 import org.sonarqube.ws.client.WsClientFactories;
+import org.sonarqube.ws.client.rules.SearchRequest;
 
 /**
  * Exercises the {@code org.sonar.plugins.rust.api.RustRulesRepository} extension point on the
@@ -49,11 +49,15 @@ class RustRulesRepositoryApiTest {
   private static final String BASE_REPOSITORY = "rust";
   private static final String OVERRIDING_RULE = "S3776";
   private static final String NEW_RULE = "S9999";
+  private static final int PAGE_SIZE = 500;
 
   @Test
   void custom_plugin_rules_are_contributed_to_sonar_way_and_reconciled() {
     var customPluginJar = customPluginJar();
-    assumeTrue(customPluginJar != null, "custom-rules-plugin jar not built (run with -Pe2e)");
+    if (customPluginJar == null) {
+      throw new IllegalStateException("custom-rules-plugin jar not found in ../custom-rules-plugin/build/libs "
+        + "(run with -Pe2e to build it before executing this test)");
+    }
 
     var orchestrator = OrchestratorExtension.builderEnv()
       .setEdition(Edition.ENTERPRISE_LW)
@@ -100,15 +104,23 @@ class RustRulesRepositoryApiTest {
   }
 
   private static Set<String> activeRuleIds(WsClient wsClient, String profileKey, String repository) {
-    var response = wsClient.rules().search(new org.sonarqube.ws.client.rules.SearchRequest()
-      .setQprofile(profileKey)
-      .setActivation("true")
-      .setLanguages(List.of(BASE_REPOSITORY))
-      .setPs("500"));
-    return response.getRulesList().stream()
-      .filter(rule -> repository.equals(rule.getRepo()))
-      .map(rule -> rule.getKey().substring(rule.getKey().indexOf(':') + 1))
-      .collect(Collectors.toSet());
+    Set<String> ruleIds = new HashSet<>();
+    int page = 1;
+    Rules.SearchResponse response;
+    do {
+      response = wsClient.rules().search(new SearchRequest()
+        .setQprofile(profileKey)
+        .setActivation("true")
+        .setLanguages(List.of(BASE_REPOSITORY))
+        .setP(String.valueOf(page))
+        .setPs(String.valueOf(PAGE_SIZE)));
+      response.getRulesList().stream()
+        .filter(rule -> repository.equals(rule.getRepo()))
+        .map(rule -> rule.getKey().substring(rule.getKey().indexOf(':') + 1))
+        .forEach(ruleIds::add);
+      page++;
+    } while ((long) response.getPaging().getPageIndex() * response.getPaging().getPageSize() < response.getPaging().getTotal());
+    return ruleIds;
   }
 
   private static File customPluginJar() {

--- a/e2e/src/test/java/org/sonarsource/rust/e2e/RustRulesRepositoryApiTest.java
+++ b/e2e/src/test/java/org/sonarsource/rust/e2e/RustRulesRepositoryApiTest.java
@@ -1,0 +1,119 @@
+/*
+ * SonarQube Rust Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.rust.e2e;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import com.sonar.orchestrator.container.Edition;
+import com.sonar.orchestrator.container.Server;
+import com.sonar.orchestrator.junit5.OrchestratorExtension;
+import com.sonar.orchestrator.locator.FileLocation;
+import java.io.File;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.sonarqube.ws.Rules;
+import org.sonarqube.ws.client.HttpConnector;
+import org.sonarqube.ws.client.WsClient;
+import org.sonarqube.ws.client.WsClientFactories;
+
+/**
+ * Exercises the {@code org.sonar.plugins.rust.api.RustRulesRepository} extension point on the
+ * sonar-rust side, independently of any other real plugin: a minimal fixture plugin
+ * (custom-rules-plugin) implements the API and contributes two rules to the built-in "Sonar way"
+ * profile.
+ *
+ * <p>Asserts the two behaviours of the API: (1) contributed rules are activated in the base-owned
+ * "Sonar way", and (2) reconciliation — the contributed {@code customrust:S3776} supersedes the
+ * base {@code rust:S3776} (same id), which is no longer active.</p>
+ */
+class RustRulesRepositoryApiTest {
+
+  private static final String CUSTOM_REPOSITORY = "customrust";
+  private static final String BASE_REPOSITORY = "rust";
+  private static final String OVERRIDING_RULE = "S3776";
+  private static final String NEW_RULE = "S9999";
+
+  @Test
+  void custom_plugin_rules_are_contributed_to_sonar_way_and_reconciled() {
+    var customPluginJar = customPluginJar();
+    assumeTrue(customPluginJar != null, "custom-rules-plugin jar not built (run with -Pe2e)");
+
+    var orchestrator = OrchestratorExtension.builderEnv()
+      .setEdition(Edition.ENTERPRISE_LW)
+      .activateLicense()
+      .useDefaultAdminCredentialsForBuilds(true)
+      .setSonarVersion(System.getProperty("sonar.runtimeVersion", "LATEST_RELEASE"))
+      .addPlugin(OrchestratorHelper.basePluginLocation())
+      .addPlugin(FileLocation.of(customPluginJar))
+      .build();
+
+    try {
+      orchestrator.start();
+      var wsClient = newAdminClient(orchestrator);
+      var sonarWayKey = builtInSonarWayKey(wsClient);
+
+      Set<String> customInProfile = activeRuleIds(wsClient, sonarWayKey, CUSTOM_REPOSITORY);
+      Set<String> baseInProfile = activeRuleIds(wsClient, sonarWayKey, BASE_REPOSITORY);
+
+      // (1) Both contributed rules are active in the base-owned "Sonar way".
+      assertThat(customInProfile).contains(OVERRIDING_RULE, NEW_RULE);
+
+      // (2) Reconciliation: the contributed rule supersedes the base rule with the same id.
+      assertThat(baseInProfile).doesNotContain(OVERRIDING_RULE);
+    } finally {
+      orchestrator.stop();
+    }
+  }
+
+  private static WsClient newAdminClient(OrchestratorExtension orchestrator) {
+    return WsClientFactories.getDefault().newClient(HttpConnector.newBuilder()
+      .url(orchestrator.getServer().getUrl())
+      .credentials(Server.ADMIN_LOGIN, Server.ADMIN_PASSWORD)
+      .build());
+  }
+
+  private static String builtInSonarWayKey(WsClient wsClient) {
+    return wsClient.qualityprofiles()
+      .search(new org.sonarqube.ws.client.qualityprofiles.SearchRequest().setLanguage(BASE_REPOSITORY))
+      .getProfilesList().stream()
+      .filter(p -> p.getIsBuiltIn() && "Sonar way".equals(p.getName()))
+      .map(org.sonarqube.ws.Qualityprofiles.SearchWsResponse.QualityProfile::getKey)
+      .findFirst()
+      .orElseThrow(() -> new AssertionError("Built-in 'Sonar way' profile for rust not found"));
+  }
+
+  private static Set<String> activeRuleIds(WsClient wsClient, String profileKey, String repository) {
+    var response = wsClient.rules().search(new org.sonarqube.ws.client.rules.SearchRequest()
+      .setQprofile(profileKey)
+      .setActivation("true")
+      .setLanguages(List.of(BASE_REPOSITORY))
+      .setPs("500"));
+    return response.getRulesList().stream()
+      .filter(rule -> repository.equals(rule.getRepo()))
+      .map(rule -> rule.getKey().substring(rule.getKey().indexOf(':') + 1))
+      .collect(Collectors.toSet());
+  }
+
+  private static File customPluginJar() {
+    var jars = new File("../custom-rules-plugin/build/libs")
+      .listFiles((dir, name) -> name.endsWith(".jar"));
+    return jars != null && jars.length > 0 ? jars[0] : null;
+  }
+}

--- a/e2e/src/test/java/org/sonarsource/rust/e2e/RustRulesRepositoryApiTest.java
+++ b/e2e/src/test/java/org/sonarsource/rust/e2e/RustRulesRepositoryApiTest.java
@@ -23,6 +23,8 @@ import com.sonar.orchestrator.container.Server;
 import com.sonar.orchestrator.junit5.OrchestratorExtension;
 import com.sonar.orchestrator.locator.FileLocation;
 import java.io.File;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -125,7 +127,10 @@ class RustRulesRepositoryApiTest {
 
   private static File customPluginJar() {
     var jars = new File("../custom-rules-plugin/build/libs")
-      .listFiles((dir, name) -> name.endsWith(".jar"));
-    return jars != null && jars.length > 0 ? jars[0] : null;
+      .listFiles((dir, name) -> name.startsWith("custom-rules-plugin-") && name.endsWith(".jar"));
+    if (jars == null || jars.length == 0) {
+      return null;
+    }
+    return Arrays.stream(jars).max(Comparator.comparingLong(File::lastModified)).orElseThrow();
   }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,3 +29,4 @@ rootProject.name = "sonar-rust-plugin"
 include("sonar-rust-plugin")
 include("analyzer")
 include("e2e")
+include("custom-rules-plugin")

--- a/sonar-rust-plugin/src/main/java/org/sonar/plugins/rust/api/RustRulesRepository.java
+++ b/sonar-rust-plugin/src/main/java/org/sonar/plugins/rust/api/RustRulesRepository.java
@@ -1,0 +1,49 @@
+/*
+ * SonarQube Rust Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.rust.api;
+
+import java.util.Collection;
+import org.sonar.api.ExtensionPoint;
+import org.sonar.api.server.ServerSide;
+
+/**
+ * Extension point allowing another plugin to contribute rules to the built-in "Sonar way"
+ * quality profile owned by the base Rust plugin.
+ *
+ * <p>This interface lives in the {@code org.sonar.plugins.rust.api} package on purpose: SonarQube
+ * loads every plugin in its own isolated classloader, with a single exception for classes located
+ * in the {@code org.sonar.plugins.<pluginKey>.api} package (here the plugin key is {@code rust}),
+ * which are made visible to other plugins. A plugin that implements this interface and registers
+ * the implementation as an extension will have it injected into the base plugin's profile
+ * definition.</p>
+ *
+ * <p>When a contributed rule id matches a rule already provided by the base {@code rust}
+ * repository, the built-in profile activates the contributed rule instead of the base one, so the
+ * contributing plugin's implementation supersedes the base one.</p>
+ */
+@ServerSide
+@ExtensionPoint
+public interface RustRulesRepository {
+
+  /**
+   * Rule keys to activate in the built-in "Sonar way" profile, each in the fully-qualified
+   * {@code "repositoryKey:ruleId"} form (for example {@code "rustenterprise:S2757"}).
+   *
+   * @return the fully-qualified keys of the rules to activate
+   */
+  Collection<String> ruleKeys();
+}

--- a/sonar-rust-plugin/src/main/java/org/sonar/plugins/rust/api/package-info.java
+++ b/sonar-rust-plugin/src/main/java/org/sonar/plugins/rust/api/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * SonarQube Rust Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+@ParametersAreNonnullByDefault
+package org.sonar.plugins.rust.api;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/RustProfile.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/RustProfile.java
@@ -16,17 +16,63 @@
  */
 package org.sonarsource.rust.plugin;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition;
+import org.sonar.plugins.rust.api.RustRulesRepository;
 import org.sonarsource.analyzer.commons.BuiltInQualityProfileJsonLoader;
 
 public class RustProfile implements BuiltInQualityProfilesDefinition {
 
   private static final String SONAR_WAY_PATH = "/org/sonar/l10n/rust/rules/rust/Sonar_way_profile.json";
 
+  private final RustRulesRepository[] repositories;
+
+  public RustProfile() {
+    this(new RustRulesRepository[0]);
+  }
+
+  public RustProfile(RustRulesRepository[] repositories) {
+    this.repositories = repositories;
+  }
+
   @Override
   public void define(Context context) {
-    var builtInQualityProfile = context.createBuiltInQualityProfile("Sonar way", RustLanguage.KEY);
-    BuiltInQualityProfileJsonLoader.load(builtInQualityProfile, RustLanguage.KEY, SONAR_WAY_PATH);
-    builtInQualityProfile.done();
+    var profile = context.createBuiltInQualityProfile("Sonar way", RustLanguage.KEY);
+
+    // Rule ids reimplemented by a contributing plugin supersede the base "rust" rule with the same
+    // id: the contributed rule is activated instead of the base one below.
+    Set<String> overriddenRuleIds = Arrays.stream(repositories)
+      .flatMap(repository -> repository.ruleKeys().stream())
+      .map(RustProfile::ruleId)
+      .collect(Collectors.toSet());
+
+    for (String baseRuleKey : BuiltInQualityProfileJsonLoader.loadActiveKeysFromJsonProfile(SONAR_WAY_PATH)) {
+      if (!overriddenRuleIds.contains(baseRuleKey)) {
+        profile.activateRule(RustLanguage.KEY, baseRuleKey);
+      }
+    }
+
+    Set<String> activated = new HashSet<>();
+    for (RustRulesRepository repository : repositories) {
+      for (String ruleKey : repository.ruleKeys()) {
+        // Guard against the same rule being contributed by more than one repository.
+        if (activated.add(ruleKey)) {
+          profile.activateRule(repositoryKey(ruleKey), ruleId(ruleKey));
+        }
+      }
+    }
+
+    profile.done();
+  }
+
+  private static String repositoryKey(String ruleKey) {
+    return ruleKey.substring(0, ruleKey.indexOf(':'));
+  }
+
+  private static String ruleId(String ruleKey) {
+    return ruleKey.substring(ruleKey.indexOf(':') + 1);
   }
 }

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/RustProfile.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/RustProfile.java
@@ -23,8 +23,12 @@ import java.util.stream.Collectors;
 import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition;
 import org.sonar.plugins.rust.api.RustRulesRepository;
 import org.sonarsource.analyzer.commons.BuiltInQualityProfileJsonLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RustProfile implements BuiltInQualityProfilesDefinition {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RustProfile.class);
 
   private static final String SONAR_WAY_PATH = "/org/sonar/l10n/rust/rules/rust/Sonar_way_profile.json";
 
@@ -50,7 +54,9 @@ public class RustProfile implements BuiltInQualityProfilesDefinition {
       .collect(Collectors.toSet());
 
     for (String baseRuleKey : BuiltInQualityProfileJsonLoader.loadActiveKeysFromJsonProfile(SONAR_WAY_PATH)) {
-      if (!overriddenRuleIds.contains(baseRuleKey)) {
+      if (overriddenRuleIds.contains(baseRuleKey)) {
+        LOG.debug("Rule rust:{} is superseded by a contributed rule", baseRuleKey);
+      } else {
         profile.activateRule(RustLanguage.KEY, baseRuleKey);
       }
     }
@@ -69,10 +75,19 @@ public class RustProfile implements BuiltInQualityProfilesDefinition {
   }
 
   private static String repositoryKey(String ruleKey) {
-    return ruleKey.substring(0, ruleKey.indexOf(':'));
+    return ruleKey.substring(0, requireColonIndex(ruleKey));
   }
 
   private static String ruleId(String ruleKey) {
-    return ruleKey.substring(ruleKey.indexOf(':') + 1);
+    return ruleKey.substring(requireColonIndex(ruleKey) + 1);
+  }
+
+  private static int requireColonIndex(String ruleKey) {
+    int colonIndex = ruleKey.indexOf(':');
+    if (colonIndex <= 0 || colonIndex == ruleKey.length() - 1) {
+      throw new IllegalStateException("Rule key contributed by a RustRulesRepository must be in the "
+        + "\"repositoryKey:ruleId\" format, got: \"" + ruleKey + "\"");
+    }
+    return colonIndex;
   }
 }

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/RustProfileTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/RustProfileTest.java
@@ -1,0 +1,85 @@
+/*
+ * SonarQube Rust Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.rust.plugin;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition;
+import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition.BuiltInActiveRule;
+import org.sonar.plugins.rust.api.RustRulesRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+class RustProfileTest {
+
+  @Test
+  void shouldActivateBaseRulesWhenNoContributor() {
+    var profile = defineProfile(new RustProfile());
+
+    assertThat(profile.rules())
+      .extracting(BuiltInActiveRule::repoKey)
+      .containsOnly("rust");
+    assertThat(profile.rules())
+      .extracting(BuiltInActiveRule::ruleKey)
+      .contains("S3776", "S2589");
+  }
+
+  @Test
+  void shouldActivateContributedRules() {
+    var profile = defineProfile(new RustProfile(new RustRulesRepository[] {
+      () -> List.of("rustenterprise:S8794", "rustenterprise:S8861")
+    }));
+
+    assertThat(profile.rules())
+      .extracting(BuiltInActiveRule::repoKey, BuiltInActiveRule::ruleKey)
+      .contains(
+        tuple("rustenterprise", "S8794"),
+        tuple("rustenterprise", "S8861"));
+  }
+
+  @Test
+  void shouldPreferContributedRuleOverBaseRuleWithSameId() {
+    // S2589 is present in the base Sonar way profile.
+    var profile = defineProfile(new RustProfile(new RustRulesRepository[] {
+      () -> List.of("rustenterprise:S2589")
+    }));
+
+    assertThat(profile.rules())
+      .extracting(BuiltInActiveRule::repoKey, BuiltInActiveRule::ruleKey)
+      .contains(tuple("rustenterprise", "S2589"))
+      .doesNotContain(tuple("rust", "S2589"));
+  }
+
+  @Test
+  void shouldActivateContributedRuleOnlyOnceWhenProvidedTwice() {
+    var profile = defineProfile(new RustProfile(new RustRulesRepository[] {
+      () -> List.of("rustenterprise:S8794"),
+      () -> List.of("rustenterprise:S8794")
+    }));
+
+    assertThat(profile.rules())
+      .filteredOn(rule -> "rustenterprise".equals(rule.repoKey()) && "S8794".equals(rule.ruleKey()))
+      .hasSize(1);
+  }
+
+  private static BuiltInQualityProfilesDefinition.BuiltInQualityProfile defineProfile(RustProfile rustProfile) {
+    var context = new BuiltInQualityProfilesDefinition.Context();
+    rustProfile.define(context);
+    return context.profile(RustLanguage.KEY, "Sonar way");
+  }
+}

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/RustProfileTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/RustProfileTest.java
@@ -23,6 +23,7 @@ import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition.BuiltInActi
 import org.sonar.plugins.rust.api.RustRulesRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 
 class RustProfileTest {
@@ -75,6 +76,17 @@ class RustProfileTest {
     assertThat(profile.rules())
       .filteredOn(rule -> "rustenterprise".equals(rule.repoKey()) && "S8794".equals(rule.ruleKey()))
       .hasSize(1);
+  }
+
+  @Test
+  void shouldRejectContributedRuleKeyWithoutColon() {
+    var profile = new RustProfile(new RustRulesRepository[] {
+      () -> List.of("rustenterpriseS8794")
+    });
+
+    assertThatThrownBy(() -> defineProfile(profile))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessageContaining("rustenterpriseS8794");
   }
 
   private static BuiltInQualityProfilesDefinition.BuiltInQualityProfile defineProfile(RustProfile rustProfile) {


### PR DESCRIPTION
## Merge order (coordinated with sonar-rust-enterprise#42)
**Merge this PR first.** It publishes the `RustRulesRepository` API in a build of `sonar-rust`. sonar-rust-enterprise#42 is currently pinned to this PR's build (`1.6.0.3113`) so the two validate together; once this merges, #42 will be updated to consume the latest `master` build (DEV) / a released version.

Part of [RUST-247](https://sonarsource.atlassian.net/browse/RUST-247). **Base half of a two-repo change — must merge before the sonar-rust-enterprise PR.**

## What
- New extension point `org.sonar.plugins.rust.api.RustRulesRepository` (`@ExtensionPoint @ServerSide`), exposing `Collection<String> ruleKeys()` in `"repository:ruleId"` form.
- The `api` package uses the `org.sonar.plugins.<pluginKey>.api` convention so SonarQube makes it visible across isolated plugin classloaders.
- `RustProfile` now takes an injected `RustRulesRepository[]` (with a no-arg fallback) and activates the contributed keys in the built-in "Sonar way" profile.

## Reconciliation
When a contributed rule id collides with a base `rust` rule of the same id, the profile activates the contributed rule **instead of** the base one. Since SonarQube discards issues for rules not active in the applied profile, the contributing plugin's implementation supersedes the base one — no analyzer changes, no duplicate issues, and standalone installs keep the base rule.

## Tests
`RustProfileTest`: base-only, contributed rules, collision-supersede, and dedup.

[RUST-247]: https://sonarsource.atlassian.net/browse/RUST-247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Independent e2e coverage (added)
A minimal **fixture plugin** (`custom-rules-plugin`, not published) implements `RustRulesRepository` and contributes two rules. `RustRulesRepositoryApiTest` installs it alongside the base plugin and asserts the API end-to-end **without any other real plugin**:
- both contributed rules (`customrust:S3776`, `customrust:S9999`) are active in the built-in "Sonar way";
- reconciliation: the contributed `customrust:S3776` supersedes base `rust:S3776` (same id), which is no longer active.

Ran locally against SonarQube EE: **passed**.
