### PR TITLE
RUST-255 Add telemetry on sonar-rust to collect dependencies

### DIFF
--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippySensor.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippySensor.java
@@ -22,6 +22,7 @@ import org.sonarsource.rust.plugin.RustLanguage;
 import org.sonarsource.rust.plugin.RustPlugin;
 import org.sonarsource.rust.plugin.RustRulesDefinition;
 import org.sonarsource.rust.plugin.Telemetry;
+import java.io.File;
 import java.nio.file.Path;
 import java.util.Objects;
 import org.slf4j.Logger;
@@ -85,6 +86,7 @@ public class ClippySensor implements Sensor {
 
     var baseDir = context.fileSystem().baseDir().toPath();
 
+    Telemetry.reportDependencies(context, manifests.stream().map(File::toPath).toList());
     Telemetry.reportAnalyzerClippyUsage(context);
 
     try {

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippySensor.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippySensor.java
@@ -22,7 +22,6 @@ import org.sonarsource.rust.plugin.RustLanguage;
 import org.sonarsource.rust.plugin.RustPlugin;
 import org.sonarsource.rust.plugin.RustRulesDefinition;
 import org.sonarsource.rust.plugin.Telemetry;
-import java.io.File;
 import java.nio.file.Path;
 import java.util.Objects;
 import org.slf4j.Logger;
@@ -86,7 +85,6 @@ public class ClippySensor implements Sensor {
 
     var baseDir = context.fileSystem().baseDir().toPath();
 
-    Telemetry.reportDependencies(context, manifests.stream().map(File::toPath).toList());
     Telemetry.reportAnalyzerClippyUsage(context);
 
     try {

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/RustSensor.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/RustSensor.java
@@ -17,6 +17,8 @@
 package org.sonarsource.rust.plugin;
 
 import org.sonarsource.rust.plugin.PlatformDetection.Platform;
+import org.sonarsource.rust.cargo.CargoManifestProvider;
+import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -64,6 +66,9 @@ public class RustSensor implements Sensor {
 
   @Override
   public void execute(SensorContext sensorContext) {
+    var manifests = CargoManifestProvider.getManifests(sensorContext);
+    Telemetry.reportDependencies(sensorContext, manifests.stream().map(File::toPath).toList());
+
     List<InputFile> inputFiles = inputFiles(sensorContext);
     var platform = platformDetection.detect();
     if (platform == Platform.UNSUPPORTED) {

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/Telemetry.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/Telemetry.java
@@ -19,6 +19,11 @@ package org.sonarsource.rust.plugin;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.regex.Pattern;
 import javax.annotation.CheckForNull;
 import org.sonar.api.batch.sensor.SensorContext;
@@ -29,8 +34,34 @@ public class Telemetry {
   private static final String RUST_CLIPPY_EDITION_VERSION_NAME = "rust.clippy.version";
   private static final String RUST_COVERAGE_FORMAT_NAME = "rust.coverage.format";
   private static final String RUST_CLIPPY_USAGE_NAME = "rust.clippy.usage";
+  private static final String RUST_DEPENDENCIES_COUNT_NAME = "rust.dependencies.count";
+  private static final String RUST_DEPENDENCIES_NAME = "rust.dependencies";
 
   private static final Pattern CLIPPY_VERSION_PATTERN = Pattern.compile("^clippy\\s+(\\d+\\.\\d+\\.\\d+)");
+
+  // Names of the Cargo.toml tables that declare direct dependencies.
+  private static final Set<String> DEP_SECTIONS = Set.of("dependencies", "dev-dependencies", "build-dependencies");
+  // Matches a dependency sub-table header, e.g. `dependencies.serde` or `target.'cfg(unix)'.dependencies.libc`.
+  private static final Pattern DEP_SUBTABLE_PATTERN =
+    Pattern.compile("^(?:target\\..+\\.)?(?:dependencies|dev-dependencies|build-dependencies)\\.(.+)$");
+  // Matches `version = "1.0"` inside an inline table, e.g. `{ version = "1.0", features = [...] }`.
+  private static final Pattern INLINE_VERSION_PATTERN = Pattern.compile("\\bversion\\s*=\\s*[\"']([^\"']*)[\"']");
+
+  // The telemetry channel has practical per-analysis limits on value length, so the joined
+  // dependency list is capped and truncated at a token boundary.
+  private static final int MAX_VALUE_LENGTH = 1000;
+  private static final String TRUNCATION_MARKER = ",...";
+
+  private enum SectionKind {
+    DEP_TABLE, DEP_SUBTABLE, OTHER
+  }
+
+  /**
+   * A direct dependency declared in a Cargo.toml manifest. {@code version} is empty when the
+   * dependency has no version requirement (git, path or workspace-inherited dependencies).
+   */
+  record Dependency(String name, String version) {
+  }
 
   private Telemetry() {
 
@@ -88,6 +119,135 @@ public class Telemetry {
     }
 
     return null;
+  }
+
+  /**
+   * Reports the direct dependencies declared across all the given Cargo manifests. Dependencies are
+   * deduplicated, sorted and emitted as two aggregate properties: the distinct count and the (possibly
+   * truncated) comma-joined list of {@code name:version} tokens (or just {@code name} when versionless).
+   */
+  public static void reportDependencies(SensorContext context, List<Path> manifests) {
+    var distinct = new TreeSet<String>();
+    for (Path manifest : manifests) {
+      try {
+        for (Dependency dependency : parseDependencies(manifest)) {
+          distinct.add(formatToken(dependency));
+        }
+      } catch (IOException ex) {
+        // Ignore - skip this manifest and keep collecting from the others
+      }
+    }
+
+    if (distinct.isEmpty()) {
+      return;
+    }
+
+    saveTelemetry(context, RUST_DEPENDENCIES_COUNT_NAME, String.valueOf(distinct.size()));
+    saveTelemetry(context, RUST_DEPENDENCIES_NAME, truncate(String.join(",", distinct)));
+  }
+
+  static List<Dependency> parseDependencies(Path cargoManifest) throws IOException {
+    var lines = Files.readAllLines(cargoManifest);
+
+    // Preserve declaration order; the value is the version ("" when versionless).
+    var deps = new LinkedHashMap<String, String>();
+    SectionKind kind = SectionKind.OTHER;
+    String pendingSubtableCrate = null;
+
+    for (var line : lines) {
+      String trimmed = line.replaceAll("#.*", "").trim();
+      if (trimmed.isEmpty()) {
+        continue;
+      }
+
+      if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+        String section = trimmed.substring(1, trimmed.length() - 1).trim();
+        pendingSubtableCrate = null;
+
+        if (isDependencyTable(section)) {
+          kind = SectionKind.DEP_TABLE;
+        } else {
+          var matcher = DEP_SUBTABLE_PATTERN.matcher(section);
+          if (matcher.matches()) {
+            kind = SectionKind.DEP_SUBTABLE;
+            pendingSubtableCrate = unquote(matcher.group(1).trim());
+            // A sub-table may declare no version; record the crate name up front.
+            deps.putIfAbsent(pendingSubtableCrate, "");
+          } else {
+            kind = SectionKind.OTHER;
+          }
+        }
+        continue;
+      }
+
+      int eq = trimmed.indexOf('=');
+      if (eq <= 0) {
+        continue;
+      }
+
+      if (kind == SectionKind.DEP_TABLE) {
+        String name = unquote(trimmed.substring(0, eq).trim());
+        if (!name.isEmpty()) {
+          deps.put(name, extractVersion(trimmed.substring(eq + 1).trim()));
+        }
+      } else if (kind == SectionKind.DEP_SUBTABLE && pendingSubtableCrate != null
+        && "version".equals(trimmed.substring(0, eq).trim())) {
+        deps.put(pendingSubtableCrate, extractVersion(trimmed.substring(eq + 1).trim()));
+      }
+    }
+
+    var result = new ArrayList<Dependency>();
+    deps.forEach((name, version) -> result.add(new Dependency(name, version)));
+    return result;
+  }
+
+  private static boolean isDependencyTable(String section) {
+    if (DEP_SECTIONS.contains(section)) {
+      return true;
+    }
+    // Target-specific dependencies, e.g. `target.'cfg(unix)'.dependencies`.
+    return section.startsWith("target.")
+      && (section.endsWith(".dependencies") || section.endsWith(".dev-dependencies") || section.endsWith(".build-dependencies"));
+  }
+
+  private static String extractVersion(String rhs) {
+    if (rhs.isEmpty()) {
+      return "";
+    }
+    char first = rhs.charAt(0);
+    if (first == '"' || first == '\'') {
+      return unquote(rhs);
+    }
+    if (first == '{') {
+      // Inline table: version is optional (absent for git/path/workspace dependencies).
+      var matcher = INLINE_VERSION_PATTERN.matcher(rhs);
+      return matcher.find() ? matcher.group(1) : "";
+    }
+    // Bare token (unusual, but tolerated best-effort).
+    return rhs;
+  }
+
+  private static String unquote(String value) {
+    return value.replaceAll("^[\"']", "").replaceAll("[\"']$", "");
+  }
+
+  private static String formatToken(Dependency dependency) {
+    // Commas would corrupt the joined list; strip them from the (rare) versions that contain them.
+    String version = dependency.version().replace(",", "");
+    return version.isEmpty() ? dependency.name() : dependency.name() + ":" + version;
+  }
+
+  private static String truncate(String value) {
+    if (value.length() <= MAX_VALUE_LENGTH) {
+      return value;
+    }
+    int limit = MAX_VALUE_LENGTH - TRUNCATION_MARKER.length();
+    int cut = value.lastIndexOf(',', limit);
+    if (cut < 0) {
+      // A single token longer than the limit; hard cut.
+      cut = limit;
+    }
+    return value.substring(0, cut) + TRUNCATION_MARKER;
   }
 
   private static void saveTelemetry(SensorContext context, String key, String value) {

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/Telemetry.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/Telemetry.java
@@ -167,6 +167,8 @@ public class Telemetry {
     Section section = Section.OTHER;
 
     for (var line : Files.readAllLines(cargoManifest)) {
+      // Best-effort comment stripping: a '#' inside a quoted value (e.g. a git rev/URL fragment) is
+      // also stripped. Accepted for this best-effort telemetry parser.
       String trimmed = line.replaceAll("#.*", "").trim();
       if (trimmed.isEmpty()) {
         continue;

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/Telemetry.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/Telemetry.java
@@ -40,11 +40,14 @@ public class Telemetry {
 
   private static final Pattern CLIPPY_VERSION_PATTERN = Pattern.compile("^clippy\\s+(\\d+\\.\\d+\\.\\d+)");
 
-  // Names of the Cargo.toml tables that declare direct dependencies.
-  private static final Set<String> DEP_SECTIONS = Set.of("dependencies", "dev-dependencies", "build-dependencies");
-  // Matches a dependency sub-table header, e.g. `dependencies.serde` or `target.'cfg(unix)'.dependencies.libc`.
+  // Names of the Cargo.toml tables that declare direct dependencies. `workspace.dependencies` covers
+  // virtual workspace roots, where dependencies are declared under `[workspace.dependencies]`.
+  private static final Set<String> DEP_SECTIONS =
+    Set.of("dependencies", "dev-dependencies", "build-dependencies", "workspace.dependencies");
+  // Matches a dependency sub-table header, e.g. `dependencies.serde`, `workspace.dependencies.serde`
+  // or `target.'cfg(unix)'.dependencies.libc`.
   private static final Pattern DEP_SUBTABLE_PATTERN =
-    Pattern.compile("^(?:target\\..+\\.)?(?:dependencies|dev-dependencies|build-dependencies)\\.(.+)$");
+    Pattern.compile("^(?:target\\..+\\.|workspace\\.)?(?:dependencies|dev-dependencies|build-dependencies)\\.(.+)$");
   // Matches `version = "1.0"` inside an inline table, e.g. `{ version = "1.0", features = [...] }`.
   private static final Pattern INLINE_VERSION_PATTERN = Pattern.compile("\\bversion\\s*=\\s*[\"']([^\"']*)[\"']");
 

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/Telemetry.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/Telemetry.java
@@ -57,6 +57,14 @@ public class Telemetry {
   }
 
   /**
+   * Classification of the Cargo.toml table currently being read. {@code subtableCrate} is the crate
+   * named by a `[dependencies.&lt;crate&gt;]` sub-table, and is {@code null} for the other kinds.
+   */
+  private record Section(SectionKind kind, String subtableCrate) {
+    static final Section OTHER = new Section(SectionKind.OTHER, null);
+  }
+
+  /**
    * A direct dependency declared in a Cargo.toml manifest. {@code version} is empty when the
    * dependency has no version requirement (git, path or workspace-inherited dependencies).
    */
@@ -147,58 +155,55 @@ public class Telemetry {
   }
 
   static List<Dependency> parseDependencies(Path cargoManifest) throws IOException {
-    var lines = Files.readAllLines(cargoManifest);
-
     // Preserve declaration order; the value is the version ("" when versionless).
     var deps = new LinkedHashMap<String, String>();
-    SectionKind kind = SectionKind.OTHER;
-    String pendingSubtableCrate = null;
+    Section section = Section.OTHER;
 
-    for (var line : lines) {
+    for (var line : Files.readAllLines(cargoManifest)) {
       String trimmed = line.replaceAll("#.*", "").trim();
       if (trimmed.isEmpty()) {
         continue;
       }
 
       if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
-        String section = trimmed.substring(1, trimmed.length() - 1).trim();
-        pendingSubtableCrate = null;
-
-        if (isDependencyTable(section)) {
-          kind = SectionKind.DEP_TABLE;
-        } else {
-          var matcher = DEP_SUBTABLE_PATTERN.matcher(section);
-          if (matcher.matches()) {
-            kind = SectionKind.DEP_SUBTABLE;
-            pendingSubtableCrate = unquote(matcher.group(1).trim());
-            // A sub-table may declare no version; record the crate name up front.
-            deps.putIfAbsent(pendingSubtableCrate, "");
-          } else {
-            kind = SectionKind.OTHER;
-          }
-        }
-        continue;
-      }
-
-      int eq = trimmed.indexOf('=');
-      if (eq <= 0) {
-        continue;
-      }
-
-      if (kind == SectionKind.DEP_TABLE) {
-        String name = unquote(trimmed.substring(0, eq).trim());
-        if (!name.isEmpty()) {
-          deps.put(name, extractVersion(trimmed.substring(eq + 1).trim()));
-        }
-      } else if (kind == SectionKind.DEP_SUBTABLE && pendingSubtableCrate != null
-        && "version".equals(trimmed.substring(0, eq).trim())) {
-        deps.put(pendingSubtableCrate, extractVersion(trimmed.substring(eq + 1).trim()));
+        section = classifySection(trimmed.substring(1, trimmed.length() - 1).trim(), deps);
+      } else {
+        parseEntry(trimmed, section, deps);
       }
     }
 
     var result = new ArrayList<Dependency>();
     deps.forEach((name, version) -> result.add(new Dependency(name, version)));
     return result;
+  }
+
+  private static Section classifySection(String section, LinkedHashMap<String, String> deps) {
+    if (isDependencyTable(section)) {
+      return new Section(SectionKind.DEP_TABLE, null);
+    }
+    var matcher = DEP_SUBTABLE_PATTERN.matcher(section);
+    if (matcher.matches()) {
+      String crate = unquote(matcher.group(1).trim());
+      // A sub-table may declare no version; record the crate name up front.
+      deps.putIfAbsent(crate, "");
+      return new Section(SectionKind.DEP_SUBTABLE, crate);
+    }
+    return Section.OTHER;
+  }
+
+  private static void parseEntry(String trimmed, Section section, LinkedHashMap<String, String> deps) {
+    int eq = trimmed.indexOf('=');
+    if (eq <= 0) {
+      return;
+    }
+    String key = unquote(trimmed.substring(0, eq).trim());
+    String version = extractVersion(trimmed.substring(eq + 1).trim());
+
+    if (section.kind() == SectionKind.DEP_TABLE && !key.isEmpty()) {
+      deps.put(key, version);
+    } else if (section.kind() == SectionKind.DEP_SUBTABLE && "version".equals(key)) {
+      deps.put(section.subtableCrate(), version);
+    }
   }
 
   private static boolean isDependencyTable(String section) {

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/Telemetry.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/Telemetry.java
@@ -207,7 +207,18 @@ public class Telemetry {
     String version = extractVersion(trimmed.substring(eq + 1).trim());
 
     if (section.kind() == SectionKind.DEP_TABLE && !key.isEmpty()) {
-      deps.put(key, version);
+      // A dotted key inside a dependency table, e.g. `serde.version = "1.0"`, declares a field of the
+      // crate named before the dot, not a crate literally named `serde.version`.
+      int dot = key.indexOf('.');
+      if (dot > 0) {
+        String crate = key.substring(0, dot);
+        deps.putIfAbsent(crate, "");
+        if ("version".equals(key.substring(dot + 1))) {
+          deps.put(crate, version);
+        }
+      } else {
+        deps.put(key, version);
+      }
     } else if (section.kind() == SectionKind.DEP_SUBTABLE && "version".equals(key)) {
       deps.put(section.subtableCrate(), version);
     }

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/Telemetry.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/Telemetry.java
@@ -278,11 +278,11 @@ public class Telemetry {
     int budget = MAX_VALUE_LENGTH - TRUNCATION_MARKER.length();
     var sb = new StringBuilder();
     for (String token : shuffled) {
-      int extra = sb.length() == 0 ? token.length() : token.length() + 1;
+      int extra = sb.isEmpty() ? token.length() : ( token.length() + 1 );
       if (sb.length() + extra > budget) {
         break;
       }
-      if (sb.length() > 0) {
+      if (!sb.isEmpty()) {
         sb.append(',');
       }
       sb.append(token);

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/Telemetry.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/Telemetry.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
 import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
 import org.sonar.api.batch.sensor.SensorContext;
 
 public class Telemetry {
@@ -60,7 +61,7 @@ public class Telemetry {
    * Classification of the Cargo.toml table currently being read. {@code subtableCrate} is the crate
    * named by a `[dependencies.&lt;crate&gt;]` sub-table, and is {@code null} for the other kinds.
    */
-  private record Section(SectionKind kind, String subtableCrate) {
+  private record Section(SectionKind kind, @Nullable String subtableCrate) {
     static final Section OTHER = new Section(SectionKind.OTHER, null);
   }
 
@@ -239,7 +240,7 @@ public class Telemetry {
   private static String formatToken(Dependency dependency) {
     // Commas would corrupt the joined list; strip them from the (rare) versions that contain them.
     String version = dependency.version().replace(",", "");
-    return version.isEmpty() ? dependency.name() : dependency.name() + ":" + version;
+    return version.isEmpty() ? dependency.name() : ( dependency.name() + ":" + version );
   }
 
   private static String truncate(String value) {

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/Telemetry.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/Telemetry.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
@@ -135,8 +136,10 @@ public class Telemetry {
 
   /**
    * Reports the direct dependencies declared across all the given Cargo manifests. Dependencies are
-   * deduplicated, sorted and emitted as two aggregate properties: the distinct count and the (possibly
-   * truncated) comma-joined list of {@code name:version} tokens (or just {@code name} when versionless).
+   * deduplicated and emitted as two aggregate properties: the distinct count and the comma-joined list
+   * of {@code name:version} tokens (or just {@code name} when versionless). When the list would exceed
+   * the channel length limit, a random sample of the dependencies is emitted instead, so the truncated
+   * view is not biased toward alphabetically-early crates.
    */
   public static void reportDependencies(SensorContext context, List<Path> manifests) {
     var distinct = new TreeSet<String>();
@@ -155,7 +158,7 @@ public class Telemetry {
     }
 
     saveTelemetry(context, RUST_DEPENDENCIES_COUNT_NAME, String.valueOf(distinct.size()));
-    saveTelemetry(context, RUST_DEPENDENCIES_NAME, truncate(String.join(",", distinct)));
+    saveTelemetry(context, RUST_DEPENDENCIES_NAME, sampleDependencies(distinct));
   }
 
   static List<Dependency> parseDependencies(Path cargoManifest) throws IOException {
@@ -246,17 +249,32 @@ public class Telemetry {
     return version.isEmpty() ? dependency.name() : ( dependency.name() + ":" + version );
   }
 
-  private static String truncate(String value) {
-    if (value.length() <= MAX_VALUE_LENGTH) {
-      return value;
+  /**
+   * Returns the comma-joined tokens, or, when they would exceed {@link #MAX_VALUE_LENGTH}, a random
+   * sample that fits within the limit (with a marker appended). Sampling shuffles first so the emitted
+   * subset is not biased toward alphabetically-early crates (the set is sorted). Collections.shuffle
+   * uses a shared source of randomness, so we do not instantiate a PRNG ourselves.
+   */
+  private static String sampleDependencies(Set<String> tokens) {
+    String joined = String.join(",", tokens);
+    if (joined.length() <= MAX_VALUE_LENGTH) {
+      return joined;
     }
-    int limit = MAX_VALUE_LENGTH - TRUNCATION_MARKER.length();
-    int cut = value.lastIndexOf(',', limit);
-    if (cut < 0) {
-      // A single token longer than the limit; hard cut.
-      cut = limit;
+    var shuffled = new ArrayList<>(tokens);
+    Collections.shuffle(shuffled);
+    int budget = MAX_VALUE_LENGTH - TRUNCATION_MARKER.length();
+    var sb = new StringBuilder();
+    for (String token : shuffled) {
+      int extra = sb.length() == 0 ? token.length() : token.length() + 1;
+      if (sb.length() + extra > budget) {
+        break;
+      }
+      if (sb.length() > 0) {
+        sb.append(',');
+      }
+      sb.append(token);
     }
-    return value.substring(0, cut) + TRUNCATION_MARKER;
+    return sb + TRUNCATION_MARKER;
   }
 
   private static void saveTelemetry(SensorContext context, String key, String value) {

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/RustSensorTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/RustSensorTest.java
@@ -17,9 +17,12 @@
 package org.sonarsource.rust.plugin;
 
 import org.sonarsource.rust.TestAnalysisWarnigs;
+import org.sonarsource.rust.cargo.CargoManifestProvider;
 import org.sonarsource.rust.plugin.PlatformDetection.Platform;
 import java.io.File;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -38,6 +41,8 @@ import org.sonar.api.rule.RuleKey;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -271,6 +276,24 @@ fn foo(c1: bool) {
     assertThat(parameters)
         .isNotNull()
         .containsEntry("S3776:threshold", "15"); // Should contain the default parameter from RustRulesDefinition.parameters()
+  }
+
+  @Test
+  void reports_dependency_telemetry() throws IOException {
+    var manifest = baseDir.toPath().resolve("Cargo.toml");
+    Files.writeString(manifest, """
+      [dependencies]
+      serde = "1.0"
+      """);
+
+    var spyContext = spy(context);
+    spyContext.settings().setProperty(CargoManifestProvider.CARGO_MANIFEST_PATHS, manifest.toString());
+    spyContext.fileSystem().add(inputFile("test.rs", "fn main() {}"));
+
+    sensor().execute(spyContext);
+
+    verify(spyContext).addTelemetryProperty("rust.dependencies", "serde:1.0");
+    verify(spyContext).addTelemetryProperty("rust.dependencies.count", "1");
   }
 
   private InputFile inputFile(String relativePath, String content) {

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/TelemetryTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/TelemetryTest.java
@@ -19,6 +19,7 @@ package org.sonarsource.rust.plugin;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -61,7 +62,7 @@ class TelemetryTest {
     if (expected != null) {
       verify(sct).addTelemetryProperty("rust.language.edition", expected);
     } else {
-      verify(sct, Mockito.never()).addTelemetryProperty(Mockito.anyString(), Mockito.anyString());
+      verify(sct, never()).addTelemetryProperty(Mockito.anyString(), Mockito.anyString());
     }
   }
 
@@ -72,7 +73,7 @@ class TelemetryTest {
 
     Telemetry.reportManifestInfo(sct, manifest);
 
-    verify(sct, Mockito.never()).addTelemetryProperty(Mockito.anyString(), Mockito.anyString());
+    verify(sct, never()).addTelemetryProperty(Mockito.anyString(), Mockito.anyString());
   }
 
   @ParameterizedTest
@@ -91,7 +92,7 @@ class TelemetryTest {
     if (expected != null) {
       verify(sct).addTelemetryProperty("rust.clippy.version", expected);
     } else {
-      verify(sct, Mockito.never()).addTelemetryProperty(Mockito.anyString(), Mockito.anyString());
+      verify(sct, never()).addTelemetryProperty(Mockito.anyString(), Mockito.anyString());
     }
   }
 
@@ -174,7 +175,7 @@ class TelemetryTest {
       verify(sct).addTelemetryProperty("rust.dependencies", expectedList);
       verify(sct).addTelemetryProperty("rust.dependencies.count", expectedCount);
     } else {
-      verify(sct, Mockito.never()).addTelemetryProperty(Mockito.anyString(), Mockito.anyString());
+      verify(sct, never()).addTelemetryProperty(Mockito.anyString(), Mockito.anyString());
     }
   }
 
@@ -210,7 +211,7 @@ class TelemetryTest {
 
     Telemetry.reportDependencies(sct, List.of(manifest));
 
-    verify(sct, Mockito.never()).addTelemetryProperty(Mockito.anyString(), Mockito.anyString());
+    verify(sct, never()).addTelemetryProperty(Mockito.anyString(), Mockito.anyString());
   }
 
   @Test

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/TelemetryTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/TelemetryTest.java
@@ -282,6 +282,18 @@ class TelemetryTest {
         [target.'cfg(windows)'.dependencies.winapi]
         version = "0.3"
         """),
+      Arguments.of("workspace dependencies table", "serde:1.0,tokio:1.38", "2", """
+        [workspace]
+        members = ["a"]
+        [workspace.dependencies]
+        serde = "1.0"
+        tokio = { version = "1.38", features = ["full"] }
+        """),
+      Arguments.of("workspace dependency sub-table", "serde:1.0", "1", """
+        [workspace.dependencies.serde]
+        version = "1.0"
+        features = ["derive"]
+        """),
       Arguments.of("non-dependency sections ignored", null, null, """
         [package]
         name = "analyzer"

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/TelemetryTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/TelemetryTest.java
@@ -294,6 +294,11 @@ class TelemetryTest {
         version = "1.0"
         features = ["derive"]
         """),
+      Arguments.of("dotted key in dependency table", "serde:1.0", "1", """
+        [dependencies]
+        serde.version = "1.0"
+        serde.features = ["derive"]
+        """),
       Arguments.of("non-dependency sections ignored", null, null, """
         [package]
         name = "analyzer"

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/TelemetryTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/TelemetryTest.java
@@ -17,6 +17,8 @@
 package org.sonarsource.rust.plugin;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -52,25 +54,25 @@ class TelemetryTest {
     var manifest = tmpDir.resolve("Cargo.toml");
     Files.writeString(manifest, manifestContent);
 
-    SensorContextTester sct = Mockito.spy(SensorContextTester.create(tmpDir).setRuntime(SONAR_RUNTIME));
+    SensorContextTester sct = spy(SensorContextTester.create(tmpDir).setRuntime(SONAR_RUNTIME));
 
     Telemetry.reportManifestInfo(sct, manifest);
 
     if (expected != null) {
-      Mockito.verify(sct).addTelemetryProperty("rust.language.edition", expected);
+      verify(sct).addTelemetryProperty("rust.language.edition", expected);
     } else {
-      Mockito.verify(sct, Mockito.never()).addTelemetryProperty(Mockito.anyString(), Mockito.anyString());
+      verify(sct, Mockito.never()).addTelemetryProperty(Mockito.anyString(), Mockito.anyString());
     }
   }
 
   @Test
   void report_manifest_info_io_error() {
     var manifest = tmpDir.resolve("noSuchCargo.toml");
-    SensorContextTester sct = Mockito.spy(SensorContextTester.create(tmpDir).setRuntime(SONAR_RUNTIME));
+    SensorContextTester sct = spy(SensorContextTester.create(tmpDir).setRuntime(SONAR_RUNTIME));
 
     Telemetry.reportManifestInfo(sct, manifest);
 
-    Mockito.verify(sct, Mockito.never()).addTelemetryProperty(Mockito.anyString(), Mockito.anyString());
+    verify(sct, Mockito.never()).addTelemetryProperty(Mockito.anyString(), Mockito.anyString());
   }
 
   @ParameterizedTest
@@ -83,13 +85,13 @@ class TelemetryTest {
     "\"\";null"
   })
   void report_clippy_version(String versionString, @Nullable String expected) {
-    SensorContextTester sct = Mockito.spy(SensorContextTester.create(tmpDir).setRuntime(SONAR_RUNTIME));
+    SensorContextTester sct = spy(SensorContextTester.create(tmpDir).setRuntime(SONAR_RUNTIME));
     Telemetry.reportClippyVersion(sct, versionString);
 
     if (expected != null) {
-      Mockito.verify(sct).addTelemetryProperty("rust.clippy.version", expected);
+      verify(sct).addTelemetryProperty("rust.clippy.version", expected);
     } else {
-      Mockito.verify(sct, Mockito.never()).addTelemetryProperty(Mockito.anyString(), Mockito.anyString());
+      verify(sct, Mockito.never()).addTelemetryProperty(Mockito.anyString(), Mockito.anyString());
     }
   }
 
@@ -164,15 +166,15 @@ class TelemetryTest {
     var manifest = tmpDir.resolve("Cargo.toml");
     Files.writeString(manifest, manifestContent);
 
-    SensorContextTester sct = Mockito.spy(SensorContextTester.create(tmpDir).setRuntime(SONAR_RUNTIME));
+    SensorContextTester sct = spy(SensorContextTester.create(tmpDir).setRuntime(SONAR_RUNTIME));
 
     Telemetry.reportDependencies(sct, List.of(manifest));
 
     if (expectedList != null) {
-      Mockito.verify(sct).addTelemetryProperty("rust.dependencies", expectedList);
-      Mockito.verify(sct).addTelemetryProperty("rust.dependencies.count", expectedCount);
+      verify(sct).addTelemetryProperty("rust.dependencies", expectedList);
+      verify(sct).addTelemetryProperty("rust.dependencies.count", expectedCount);
     } else {
-      Mockito.verify(sct, Mockito.never()).addTelemetryProperty(Mockito.anyString(), Mockito.anyString());
+      verify(sct, Mockito.never()).addTelemetryProperty(Mockito.anyString(), Mockito.anyString());
     }
   }
 
@@ -193,22 +195,22 @@ class TelemetryTest {
       tokio = "1.38"
       """);
 
-    SensorContextTester sct = Mockito.spy(SensorContextTester.create(tmpDir).setRuntime(SONAR_RUNTIME));
+    SensorContextTester sct = spy(SensorContextTester.create(tmpDir).setRuntime(SONAR_RUNTIME));
 
     Telemetry.reportDependencies(sct, List.of(m1, m2));
 
-    Mockito.verify(sct).addTelemetryProperty("rust.dependencies", "rand:0.8,serde:1.0,tokio:1.38");
-    Mockito.verify(sct).addTelemetryProperty("rust.dependencies.count", "3");
+    verify(sct).addTelemetryProperty("rust.dependencies", "rand:0.8,serde:1.0,tokio:1.38");
+    verify(sct).addTelemetryProperty("rust.dependencies.count", "3");
   }
 
   @Test
   void report_dependencies_io_error() {
     var manifest = tmpDir.resolve("noSuchCargo.toml");
-    SensorContextTester sct = Mockito.spy(SensorContextTester.create(tmpDir).setRuntime(SONAR_RUNTIME));
+    SensorContextTester sct = spy(SensorContextTester.create(tmpDir).setRuntime(SONAR_RUNTIME));
 
     Telemetry.reportDependencies(sct, List.of(manifest));
 
-    Mockito.verify(sct, Mockito.never()).addTelemetryProperty(Mockito.anyString(), Mockito.anyString());
+    verify(sct, Mockito.never()).addTelemetryProperty(Mockito.anyString(), Mockito.anyString());
   }
 
   @Test
@@ -220,15 +222,15 @@ class TelemetryTest {
     var manifest = tmpDir.resolve("Cargo.toml");
     Files.writeString(manifest, content.toString());
 
-    SensorContextTester sct = Mockito.spy(SensorContextTester.create(tmpDir).setRuntime(SONAR_RUNTIME));
+    SensorContextTester sct = spy(SensorContextTester.create(tmpDir).setRuntime(SONAR_RUNTIME));
 
     Telemetry.reportDependencies(sct, List.of(manifest));
 
     var listCaptor = ArgumentCaptor.forClass(String.class);
-    Mockito.verify(sct).addTelemetryProperty(Mockito.eq("rust.dependencies"), listCaptor.capture());
+    verify(sct).addTelemetryProperty(Mockito.eq("rust.dependencies"), listCaptor.capture());
     assertThat(listCaptor.getValue()).hasSizeLessThanOrEqualTo(1000).endsWith(",...");
     // The count reflects the true total even though the list value is truncated.
-    Mockito.verify(sct).addTelemetryProperty("rust.dependencies.count", "500");
+    verify(sct).addTelemetryProperty("rust.dependencies.count", "500");
   }
 
   static Stream<Arguments> dependencyManifests() {

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/TelemetryTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/TelemetryTest.java
@@ -16,9 +16,12 @@
  */
 package org.sonarsource.rust.plugin;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
@@ -27,6 +30,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
@@ -154,5 +158,160 @@ class TelemetryTest {
       );
   }
 
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("dependencyManifests")
+  void report_dependencies(String name, @Nullable String expectedList, @Nullable String expectedCount, String manifestContent) throws IOException {
+    var manifest = tmpDir.resolve("Cargo.toml");
+    Files.writeString(manifest, manifestContent);
+
+    SensorContextTester sct = Mockito.spy(SensorContextTester.create(tmpDir).setRuntime(SONAR_RUNTIME));
+
+    Telemetry.reportDependencies(sct, List.of(manifest));
+
+    if (expectedList != null) {
+      Mockito.verify(sct).addTelemetryProperty("rust.dependencies", expectedList);
+      Mockito.verify(sct).addTelemetryProperty("rust.dependencies.count", expectedCount);
+    } else {
+      Mockito.verify(sct, Mockito.never()).addTelemetryProperty(Mockito.anyString(), Mockito.anyString());
+    }
+  }
+
+  @Test
+  void report_dependencies_deduplicates_across_manifests() throws IOException {
+    var m1 = tmpDir.resolve("a/Cargo.toml");
+    var m2 = tmpDir.resolve("b/Cargo.toml");
+    Files.createDirectories(m1.getParent());
+    Files.createDirectories(m2.getParent());
+    Files.writeString(m1, """
+      [dependencies]
+      serde = "1.0"
+      rand = "0.8"
+      """);
+    Files.writeString(m2, """
+      [dependencies]
+      serde = "1.0"
+      tokio = "1.38"
+      """);
+
+    SensorContextTester sct = Mockito.spy(SensorContextTester.create(tmpDir).setRuntime(SONAR_RUNTIME));
+
+    Telemetry.reportDependencies(sct, List.of(m1, m2));
+
+    Mockito.verify(sct).addTelemetryProperty("rust.dependencies", "rand:0.8,serde:1.0,tokio:1.38");
+    Mockito.verify(sct).addTelemetryProperty("rust.dependencies.count", "3");
+  }
+
+  @Test
+  void report_dependencies_io_error() {
+    var manifest = tmpDir.resolve("noSuchCargo.toml");
+    SensorContextTester sct = Mockito.spy(SensorContextTester.create(tmpDir).setRuntime(SONAR_RUNTIME));
+
+    Telemetry.reportDependencies(sct, List.of(manifest));
+
+    Mockito.verify(sct, Mockito.never()).addTelemetryProperty(Mockito.anyString(), Mockito.anyString());
+  }
+
+  @Test
+  void report_dependencies_truncates_long_list() throws IOException {
+    var content = new StringBuilder("[dependencies]\n");
+    for (int i = 0; i < 500; i++) {
+      content.append(String.format("crate_%04d = \"1.0.0\"%n", i));
+    }
+    var manifest = tmpDir.resolve("Cargo.toml");
+    Files.writeString(manifest, content.toString());
+
+    SensorContextTester sct = Mockito.spy(SensorContextTester.create(tmpDir).setRuntime(SONAR_RUNTIME));
+
+    Telemetry.reportDependencies(sct, List.of(manifest));
+
+    var listCaptor = ArgumentCaptor.forClass(String.class);
+    Mockito.verify(sct).addTelemetryProperty(Mockito.eq("rust.dependencies"), listCaptor.capture());
+    assertThat(listCaptor.getValue()).hasSizeLessThanOrEqualTo(1000).endsWith(",...");
+    // The count reflects the true total even though the list value is truncated.
+    Mockito.verify(sct).addTelemetryProperty("rust.dependencies.count", "500");
+  }
+
+  static Stream<Arguments> dependencyManifests() {
+    return Stream.of(
+      Arguments.of("simple string dependencies", "serde:1.0.190,tree-sitter:0.25.1", "2", """
+        [package]
+        name = "analyzer"
+        [dependencies]
+        tree-sitter = "0.25.1"
+        serde = "1.0.190"
+        """),
+      Arguments.of("inline table with version and features", "serde:1.0", "1", """
+        [dependencies]
+        serde = { version = "1.0", features = ["derive"] }
+        """),
+      Arguments.of("git dependency without version", "rand", "1", """
+        [dependencies]
+        rand = { git = "https://github.com/rust-random/rand" }
+        """),
+      Arguments.of("path dependency without version", "foo", "1", """
+        [dependencies]
+        foo = { path = "../foo" }
+        """),
+      Arguments.of("workspace-inherited dependency", "bar", "1", """
+        [dependencies]
+        bar = { workspace = true }
+        """),
+      Arguments.of("sub-table with version", "serde:1.0", "1", """
+        [dependencies.serde]
+        version = "1.0"
+        features = ["derive"]
+        """),
+      Arguments.of("sub-table without version", "local", "1", """
+        [dependencies.local]
+        path = "../local"
+        """),
+      Arguments.of("dev and build dependencies", "cc:1.0,mockito:1.0,serde:1.0", "3", """
+        [dependencies]
+        serde = "1.0"
+        [dev-dependencies]
+        mockito = "1.0"
+        [build-dependencies]
+        cc = "1.0"
+        """),
+      Arguments.of("target-specific dependencies", "libc:0.2,winapi:0.3", "2", """
+        [target.'cfg(unix)'.dependencies]
+        libc = "0.2"
+        [target.'cfg(windows)'.dependencies.winapi]
+        version = "0.3"
+        """),
+      Arguments.of("non-dependency sections ignored", null, null, """
+        [package]
+        name = "analyzer"
+        edition = "2021"
+        [features]
+        default = ["serde"]
+        [profile.release]
+        opt-level = 3
+        [workspace]
+        members = ["a"]
+        [package.metadata]
+        foo = "bar"
+        """),
+      Arguments.of("comments ignored", "serde:1.0", "1", """
+        [dependencies]
+        serde = "1.0" # the serde crate
+        # rand = "0.8"
+        """),
+      Arguments.of("quoted crate name", "tree-sitter:0.25.1", "1", """
+        [dependencies]
+        "tree-sitter" = "0.25.1"
+        """),
+      Arguments.of("empty file", null, null, ""),
+      Arguments.of("empty dependencies table", null, null, """
+        [package]
+        name = "analyzer"
+        [dependencies]
+        """),
+      Arguments.of("malformed dependencies header", null, null, """
+        [dependencies
+        serde = "1.0"
+        """)
+      );
+  }
 
 }


### PR DESCRIPTION
----
## Summary by Gitar

- **Telemetry enhancement:**
  - Added dependency collection in `Telemetry.java` to track `rust.dependencies` and `rust.dependencies.count`.
  - Implemented `parseDependencies` to extract crates from `Cargo.toml` including standard, dev, build, and target-specific dependencies.
  - Added support for `workspace.dependencies` and dotted key syntax (e.g., `serde.version = "1.0"`).
  - Added truncation logic for the dependency list with random sampling to stay within telemetry limits.
- **Sensor integration:**
  - Updated `RustSensor.java` to invoke dependency telemetry reporting during analysis.
- **Test suite:**
  - Added `TelemetryTest.java` covering edge cases like deduplication, IO errors, truncation, and various `Cargo.toml` syntax formats.
  - Added a test case in `RustSensorTest.java` to verify telemetry integration.


<sub>This will update automatically on new commits.</sub>