### PR TITLE
RUST-258 Use squad Renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>SonarSource/core-languages-tooling-public:renovate-config"
+    "local>SonarSource/core-languages-tooling-public:languages-team"
   ],
-  "addLabels": [
-    "dependencies"
-  ],
-  "rebaseWhen": "conflicted",
-  "minimumReleaseAgeBehaviour": "timestamp-required",
   "enabledManagers": [
     "github-actions",
     "gradle",
@@ -19,31 +14,6 @@
     "e2e/src/test/resources/**"
   ],
   "packageRules": [
-    {
-      "description": "Group Gradle updates",
-      "matchManagers": [
-        "gradle",
-        "gradle-wrapper"
-      ],
-      "groupName": "Gradle dependencies",
-      "groupSlug": "gradle-dependencies"
-    },
-    {
-      "description": "Group npm updates",
-      "matchManagers": [
-        "npm"
-      ],
-      "groupName": "npm dependencies",
-      "groupSlug": "npm-dependencies"
-    },
-    {
-      "description": "Group Mise tool updates",
-      "matchManagers": [
-        "mise"
-      ],
-      "groupName": "Mise tool dependencies",
-      "groupSlug": "mise-tool-dependencies"
-    },
     {
       "matchManagers": [
         "gradle"

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>SonarSource/renovate-config:languages-team"
+    "local>SonarSource/core-languages-tooling-public:renovate-config"
   ],
+  "addLabels": [
+    "dependencies"
+  ],
+  "rebaseWhen": "conflicted",
+  "minimumReleaseAgeBehaviour": "timestamp-required",
   "enabledManagers": [
     "github-actions",
     "gradle",
@@ -14,6 +19,31 @@
     "e2e/src/test/resources/**"
   ],
   "packageRules": [
+    {
+      "description": "Group Gradle updates",
+      "matchManagers": [
+        "gradle",
+        "gradle-wrapper"
+      ],
+      "groupName": "Gradle dependencies",
+      "groupSlug": "gradle-dependencies"
+    },
+    {
+      "description": "Group npm updates",
+      "matchManagers": [
+        "npm"
+      ],
+      "groupName": "npm dependencies",
+      "groupSlug": "npm-dependencies"
+    },
+    {
+      "description": "Group Mise tool updates",
+      "matchManagers": [
+        "mise"
+      ],
+      "groupName": "Mise tool dependencies",
+      "groupSlug": "mise-tool-dependencies"
+    },
     {
       "matchManagers": [
         "gradle"

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>SonarSource/core-languages-tooling-public:languages-team"
+    "local>SonarSource/core-languages-tooling-public:renovate-config"
   ],
   "enabledManagers": [
     "github-actions",


### PR DESCRIPTION
## Summary
- switch this repository to the squad Renovate preset
- keep only repo-specific Renovate behavior in the repository

## Effective Delta After Merge
<!-- codex-effective-delta:start -->
- rebaseWhen: conflicted -> never
- minimumReleaseAgeBehaviour: timestamp-required -> timestamp-optional
- prCreation: not-pending -> immediate
- packageRules removed: {"matchManagers":["regex"],"versioning":"regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+).(?<build>\\d+)?$"}
- packageRules added: Don't group updates by default
- regexManagers: 1 -> 0
<!-- codex-effective-delta:end -->
