### PR TITLE
PREQ-7325 Add self-hosted Renovate dry run

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,40 @@
+---
+name: Renovate dry run
+
+on:
+  workflow_dispatch:
+
+jobs:
+  renovate:
+    runs-on: github-ubuntu-latest-s
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - id: secrets
+        uses: SonarSource/vault-action-wrapper@v3
+        with:
+          secrets: |
+            development/github/token/{REPO_OWNER_NAME_DASH}-renovate token | renovate_token;
+            development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader username | artifactory_username;
+            development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | artifactory_password;
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Self-hosted Renovate dry run
+        uses: renovatebot/github-action@3064367f740a1a91cca218698a63902689cce200 # v46.1.20
+        env:
+          ARTIFACTORY_PRIVATE_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).artifactory_password }}
+          ARTIFACTORY_PRIVATE_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).artifactory_username }}
+          LOG_LEVEL: debug
+          RENOVATE_ALLOWED_COMMANDS: >-
+            ["^[.]/gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 properties$",
+            "^[.]/gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 :sonar-rust-plugin:dependencies --configuration jacocoAgent$",
+            "^[.]/gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 :sonar-rust-plugin:dependencies --configuration jacocoAnt$",
+            "^[.]/gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 :sonar-rust-plugin:jacocoTestReport -x :sonar-rust-plugin:test$"]
+          RENOVATE_BRANCH_PREFIX: self-hosted-renovate/
+          RENOVATE_DRY_RUN: full
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+        with:
+          env-regex: "^(?:RENOVATE_\\w+|LOG_LEVEL|ARTIFACTORY_PRIVATE_(?:USERNAME|PASSWORD))$"
+          renovate-version: 43.275.2
+          token: ${{ fromJSON(steps.secrets.outputs.vault).renovate_token }}


### PR DESCRIPTION
## Summary

- Add a manually dispatched self-hosted Renovate workflow.
- Run Renovate `43.275.2` in full dry-run mode with the repository-scoped GitHub token from Vault.
- Pass the existing Artifactory private-reader credentials into the Renovate container.
- Allow exactly the four Gradle post-upgrade commands configured in `.github/renovate.json`.

## Context

[sonar-rust#296](https://github.com/SonarSource/sonar-rust/pull/296) shows that Mend Hosted Renovate rejects the Gradle commands needed to refresh dependency locks and verification metadata. Self-hosting lets us approve those repository-specific commands.

The repository-scoped token is introduced by [re-terraform-aws-vault#9484](https://github.com/SonarSource/re-terraform-aws-vault/pull/9484) at `development/github/token/SonarSource-sonar-rust-renovate`.

## Safety and rollout

- The workflow has only a `workflow_dispatch` trigger; there is no schedule.
- `RENOVATE_DRY_RUN` is set to `full`, so Renovate performs extraction, lookup, artifact updates, and post-upgrade tasks but only logs GitHub branch and PR mutations.
- A separate `self-hosted-renovate/` branch prefix avoids overlap with Mend Hosted branches during validation.
- The workflow's own `GITHUB_TOKEN` has read-only repository contents permission.

Because GitHub only dispatches a newly added workflow after it exists on the default branch, this safe dry-run version must land before it can be exercised. After the Vault token is deployed, dispatch the workflow and inspect the debug log and generated artifact changes.

Before removing dry-run mode or adding a schedule, Eng XP/IT Ops must offboard `sonar-rust` from Mend Hosted Renovate to avoid two Renovate instances managing the repository.

## Validation

- `actionlint` passes, accounting for the SonarSource custom runner label.
- The four configured post-upgrade commands each match exactly one allowlist pattern.
- The workflow YAML and JSON-encoded command allowlist parse successfully.

Part of [PREQ-7325](https://sonarsource.atlassian.net/browse/PREQ-7325)


[PREQ-7325]: https://sonarsource.atlassian.net/browse/PREQ-7325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ