### PR TITLE
RUST-503 Aggregate manifest editions into a single telemetry key

### DIFF
--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippySensor.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/clippy/ClippySensor.java
@@ -22,6 +22,7 @@ import org.sonarsource.rust.plugin.RustLanguage;
 import org.sonarsource.rust.plugin.RustPlugin;
 import org.sonarsource.rust.plugin.RustRulesDefinition;
 import org.sonarsource.rust.plugin.Telemetry;
+import java.io.File;
 import java.nio.file.Path;
 import java.util.Objects;
 import org.slf4j.Logger;
@@ -103,10 +104,11 @@ public class ClippySensor implements Sensor {
       .filter(Objects::nonNull)
       .toList();
 
+    Telemetry.reportManifestInfo(context, manifests.stream().map(File::toPath).toList());
+
     try {
       for (var manifest : manifests) {
         Path manifestPath = manifest.toPath();
-        Telemetry.reportManifestInfo(context, manifestPath);
 
         var workDir = manifestPath.getParent();
         clippy.run(workDir, lints, diagnostic -> {

--- a/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/Telemetry.java
+++ b/sonar-rust-plugin/src/main/java/org/sonarsource/rust/plugin/Telemetry.java
@@ -99,14 +99,27 @@ public class Telemetry {
     }
   }
 
-  public static void reportManifestInfo(SensorContext context, Path cargoManifest) {
-    try {
-      String edition = findRustEdition(cargoManifest);
-      if (edition != null) {
-        saveTelemetry(context, RUST_EDITION_NAME, edition);
+  /**
+   * Reports the Rust editions declared across all the given Cargo manifests, deduplicated and
+   * comma-joined under a single property. The telemetry channel requires each key to be reported
+   * at most once per analysis, so a monorepo with several manifests (and possibly several editions)
+   * cannot report one {@code rust.language.edition} value per manifest.
+   */
+  public static void reportManifestInfo(SensorContext context, List<Path> cargoManifests) {
+    var editions = new TreeSet<String>();
+    for (Path cargoManifest : cargoManifests) {
+      try {
+        String edition = findRustEdition(cargoManifest);
+        if (edition != null) {
+          editions.add(edition);
+        }
+      } catch (IOException ex) {
+        // Ignore - skip this manifest and keep collecting from the others
       }
-    } catch (IOException ex) {
-      // Ignore - don't try to report anything if the manifest can't be read
+    }
+
+    if (!editions.isEmpty()) {
+      saveTelemetry(context, RUST_EDITION_NAME, String.join(",", editions));
     }
   }
 

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/TelemetryTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/TelemetryTest.java
@@ -18,6 +18,7 @@ package org.sonarsource.rust.plugin;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.never;
 
@@ -89,7 +90,7 @@ class TelemetryTest {
 
     Telemetry.reportManifestInfo(sct, List.of(manifest2021, manifest2018, manifest2021Duplicate));
 
-    verify(sct, Mockito.times(1)).addTelemetryProperty("rust.language.edition", "2018,2021");
+    verify(sct, times(1)).addTelemetryProperty("rust.language.edition", "2018,2021");
   }
 
   @Test

--- a/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/TelemetryTest.java
+++ b/sonar-rust-plugin/src/test/java/org/sonarsource/rust/plugin/TelemetryTest.java
@@ -57,7 +57,7 @@ class TelemetryTest {
 
     SensorContextTester sct = spy(SensorContextTester.create(tmpDir).setRuntime(SONAR_RUNTIME));
 
-    Telemetry.reportManifestInfo(sct, manifest);
+    Telemetry.reportManifestInfo(sct, List.of(manifest));
 
     if (expected != null) {
       verify(sct).addTelemetryProperty("rust.language.edition", expected);
@@ -71,9 +71,38 @@ class TelemetryTest {
     var manifest = tmpDir.resolve("noSuchCargo.toml");
     SensorContextTester sct = spy(SensorContextTester.create(tmpDir).setRuntime(SONAR_RUNTIME));
 
-    Telemetry.reportManifestInfo(sct, manifest);
+    Telemetry.reportManifestInfo(sct, List.of(manifest));
 
     verify(sct, never()).addTelemetryProperty(Mockito.anyString(), Mockito.anyString());
+  }
+
+  @Test
+  void report_manifest_info_aggregates_distinct_editions_from_several_manifests() throws IOException {
+    var manifest2021 = tmpDir.resolve("Cargo2021.toml");
+    Files.writeString(manifest2021, "[package]\nedition = \"2021\"\n");
+    var manifest2018 = tmpDir.resolve("Cargo2018.toml");
+    Files.writeString(manifest2018, "[package]\nedition = \"2018\"\n");
+    var manifest2021Duplicate = tmpDir.resolve("Cargo2021Duplicate.toml");
+    Files.writeString(manifest2021Duplicate, "[package]\nedition = \"2021\"\n");
+
+    SensorContextTester sct = spy(SensorContextTester.create(tmpDir).setRuntime(SONAR_RUNTIME));
+
+    Telemetry.reportManifestInfo(sct, List.of(manifest2021, manifest2018, manifest2021Duplicate));
+
+    verify(sct, Mockito.times(1)).addTelemetryProperty("rust.language.edition", "2018,2021");
+  }
+
+  @Test
+  void report_manifest_info_skips_unreadable_manifests_and_reports_the_rest() throws IOException {
+    var readable = tmpDir.resolve("Cargo.toml");
+    Files.writeString(readable, "[package]\nedition = \"2021\"\n");
+    var unreadable = tmpDir.resolve("noSuchCargo.toml");
+
+    SensorContextTester sct = spy(SensorContextTester.create(tmpDir).setRuntime(SONAR_RUNTIME));
+
+    Telemetry.reportManifestInfo(sct, List.of(unreadable, readable));
+
+    verify(sct).addTelemetryProperty("rust.language.edition", "2021");
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## Summary
- `ClippySensor` looped over every Cargo manifest and called `Telemetry.reportManifestInfo` once per manifest, each time writing the `rust.language.edition` key. The scanner engine now rejects duplicate telemetry keys, so analyzing a monorepo with several manifests (e.g. PR #300's E2E `testMonorepoLayout` test) crashes Clippy analysis with `Duplicate telemetry key 'rust.language.edition' was stored`.
- `Telemetry.reportManifestInfo` now takes all manifests at once and reports the distinct editions found across them as a single comma-joined, deduplicated `rust.language.edition` value.

Fixes RUST-503.