### PR TITLE
PREQ-7325 Disable Gradle configuration on demand for Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,7 +24,7 @@
           "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 properties",
           "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 :sonar-rust-plugin:dependencies --configuration jacocoAgent",
           "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 :sonar-rust-plugin:dependencies --configuration jacocoAnt",
-          "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 :sonar-rust-plugin:jacocoTestReport -x :sonar-rust-plugin:test"
+          "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 --no-configure-on-demand :sonar-rust-plugin:jacocoTestReport -x :sonar-rust-plugin:test"
         ],
         "fileFilters": [
           "**/gradle.lockfile",


### PR DESCRIPTION
## Summary

- Disable Gradle configuration-on-demand for the Jacoco Renovate post-upgrade command.
- Ensure the `analyzer` project is configured before `sonar-rust-plugin` resolves `compileRustLinuxMusl`.

## Validation

- Reproduced the `Task with name 'compileRustLinuxMusl' not found in project ':analyzer'` failure with configuration-on-demand enabled.
- Verified the same Gradle invocation succeeds with `--no-configure-on-demand`.
- Parsed `.github/renovate.json` with Node.js and ran `git diff --check`.

Jira: [PREQ-7325](https://sonarsource.atlassian.net/browse/PREQ-7325)

[PREQ-7325]: https://sonarsource.atlassian.net/browse/PREQ-7325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ