### PR TITLE
RUST-688 Align Renovate Gradle artifact updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,6 +13,7 @@
         "gradle",
         "gradle-wrapper"
       ],
+      "skipArtifactsUpdate": true,
       "constraints": {
         "java": "21"
       },

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,7 +13,6 @@
         "gradle",
         "gradle-wrapper"
       ],
-      "skipArtifactsUpdate": true,
       "constraints": {
         "java": "21"
       },
@@ -23,6 +22,7 @@
         },
         "commands": [
           "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 properties",
+          "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 :e2e:dependencies",
           "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 :sonar-rust-plugin:dependencies --configuration jacocoAgent",
           "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 :sonar-rust-plugin:dependencies --configuration jacocoAnt",
           "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 --no-configure-on-demand :sonar-rust-plugin:jacocoTestReport -x :sonar-rust-plugin:test"
@@ -33,6 +33,13 @@
           "gradle/verification-metadata.xml"
         ]
       }
+    },
+    {
+      "description": "Let repository tasks own artifacts for Gradle wrapper updates",
+      "matchManagers": [
+        "gradle-wrapper"
+      ],
+      "skipArtifactsUpdate": true
     },
     {
       "matchManagers": [


### PR DESCRIPTION
Part of

## Why

The Gradle wrapper update in #337 exposed two competing artifact update paths. Renovate's built-in wrapper updater ran before the repository's post-upgrade tasks and recorded an artifact failure against the old lockfiles and verification metadata. The repository-owned tasks then regenerated those files successfully, but the earlier failure remained attached to the PR.

The JUnit update in #334 also showed that the repository tasks must explicitly resolve E2E configurations so their lockfiles and verification metadata are complete.

## What

- Skip Renovate's built-in artifact update only for Gradle Wrapper updates.
- Keep Renovate's built-in artifact handling enabled for ordinary Gradle dependency updates.
- Resolve E2E dependencies in the repository-owned post-upgrade tasks.

## Validation

- `jq empty .github/renovate.json`
- `npx --yes --package=renovate@43.275.2 renovate-config-validator .github/renovate.json`
