### PR TITLE
RUST-689 Refresh Renovate Gradle test classpaths

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,7 +22,10 @@
         },
         "commands": [
           "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 properties",
-          "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 :e2e:dependencies",
+          "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 --refresh-dependencies :e2e:dependencies --configuration testCompileClasspath",
+          "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 :e2e:dependencies --configuration testRuntimeClasspath",
+          "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 :sonar-rust-plugin:dependencies --configuration testCompileClasspath",
+          "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 :sonar-rust-plugin:dependencies --configuration testRuntimeClasspath",
           "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 :sonar-rust-plugin:dependencies --configuration jacocoAgent",
           "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 :sonar-rust-plugin:dependencies --configuration jacocoAnt",
           "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 --no-configure-on-demand :sonar-rust-plugin:jacocoTestReport -x :sonar-rust-plugin:test"


### PR DESCRIPTION
Part of RUST-688

## Summary

- refresh dependency metadata before Renovate resolves the E2E test compile classpath
- resolve the compile and runtime test classpaths for both `e2e` and `sonar-rust-plugin`
- keep Gradle locks and verification metadata aligned with the configurations used by CI

## Validation

- `jq empty .github/renovate.json`
- `npx --yes --package renovate@43.275.2 renovate-config-validator .github/renovate.json`
- ran the new fresh-cache E2E test-compile command against the regenerated #334 branch and confirmed it adds `junit-bom-6.1.3.pom` with its SHA-256
- confirmed the stale scanner-engine entries from #341 belong to `testCompileClasspath` and `testRuntimeClasspath`, which are now resolved explicitly
