### PR TITLE
RUST-690 Target Java 21 for Renovate scanner-engine updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,15 +17,14 @@
         "java": "21"
       },
       "postUpgradeTasks": {
+        "executionMode": "branch",
         "installTools": {
           "java": {}
         },
         "commands": [
           "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 properties",
-          "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 --refresh-dependencies :e2e:dependencies --configuration testCompileClasspath",
-          "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 :e2e:dependencies --configuration testRuntimeClasspath",
-          "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 :sonar-rust-plugin:dependencies --configuration testCompileClasspath",
-          "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 :sonar-rust-plugin:dependencies --configuration testRuntimeClasspath",
+          "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 --refresh-dependencies --update-locks {{#each (distinct (lookupArray upgrades \"depName\"))}}{{{.}}}{{#unless @last}},{{/unless}}{{/each}} :e2e:dependencies --configuration testCompileClasspath :sonar-rust-plugin:dependencies --configuration testCompileClasspath",
+          "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 --update-locks {{#each (distinct (lookupArray upgrades \"depName\"))}}{{{.}}}{{#unless @last}},{{/unless}}{{/each}} :e2e:dependencies --configuration testRuntimeClasspath :sonar-rust-plugin:dependencies --configuration testRuntimeClasspath",
           "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 :sonar-rust-plugin:dependencies --configuration jacocoAgent",
           "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 :sonar-rust-plugin:dependencies --configuration jacocoAnt",
           "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 --no-configure-on-demand :sonar-rust-plugin:jacocoTestReport -x :sonar-rust-plugin:test"
@@ -43,6 +42,16 @@
         "gradle-wrapper"
       ],
       "skipArtifactsUpdate": true
+    },
+    {
+      "description": "Keep scanner engine test dependencies compatible with the Java 17 bytecode target",
+      "matchManagers": [
+        "gradle"
+      ],
+      "matchPackageNames": [
+        "/^org\\.sonarsource\\.scanner\\.engine:/"
+      ],
+      "allowedVersions": "/^13\\.6\\./"
     },
     {
       "matchManagers": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -44,16 +44,6 @@
       "skipArtifactsUpdate": true
     },
     {
-      "description": "Keep scanner engine test dependencies compatible with the Java 17 bytecode target",
-      "matchManagers": [
-        "gradle"
-      ],
-      "matchPackageNames": [
-        "/^org\\.sonarsource\\.scanner\\.engine:/"
-      ],
-      "allowedVersions": "/^13\\.6\\./"
-    },
-    {
       "matchManagers": [
         "mise"
       ],

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ We welcome your feedback and feature requests to help improve the Rust analyzer.
 
 To work on this project, you will need the following tools:
 
-- Java 17
+- Java 21
 - Rust 2021
 - Gradle
 - Cargo

--- a/custom-rules-plugin/build.gradle.kts
+++ b/custom-rules-plugin/build.gradle.kts
@@ -33,13 +33,13 @@ dependencies {
 
 java {
   toolchain {
-    // Build and run on Java 21, but keep compiling to Java 17 bytecode.
+    // Build, run, and compile bytecode for Java 21.
     languageVersion = JavaLanguageVersion.of(21)
   }
 }
 
 tasks.withType<JavaCompile>().configureEach {
-  options.release.set(17)
+  options.release.set(21)
 }
 
 sonarqube.isSkipProject = true

--- a/sonar-rust-plugin/build.gradle.kts
+++ b/sonar-rust-plugin/build.gradle.kts
@@ -55,7 +55,7 @@ dependencies {
 // Apply a specific Java toolchain to ease working on different environments.
 java {
   toolchain {
-    // Build and run on Java 21, but keep compiling to Java 17 bytecode.
+    // Build, run, and compile bytecode for Java 21.
     languageVersion = JavaLanguageVersion.of(21)
   }
   withSourcesJar()
@@ -63,7 +63,7 @@ java {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-  options.release.set(17)
+  options.release.set(21)
 }
 
 tasks.jacocoTestReport {


### PR DESCRIPTION
Part of RUST-688

## Summary

- target Java 21 for the main sonar-rust plugin and the custom-rules E2E fixture
- run Gradle post-upgrade tasks once per Renovate branch
- selectively unlock every Gradle dependency updated by the branch while resolving the E2E and plugin test classpaths
- remove the scanner-engine 13.6 restriction so Renovate can update to Java 21-compatible releases

## Context

The project selected a Java 21 toolchain but configured both Java modules with `options.release.set(17)`. Gradle therefore requested Java 17-compatible dependency variants, which made scanner-engine 13.8 incompatible even though the build itself ran on Java 21.

The branch-level Renovate task receives all dependency names from Renovate's `upgrades` array and passes them to Gradle's `--update-locks`. It resolves the combined E2E and plugin compile and runtime classpaths, refreshing the affected direct and transitive locks while leaving unrelated dependency locks unchanged.

The README, main plugin, test fixture, Renovate Java constraint, and mise configuration now consistently target Java 21.

## Validation

- `jq empty .github/renovate.json`
- `npx --yes --package renovate@43.275.2 renovate-config-validator .github/renovate.json`
- `./gradlew --no-daemon --console=plain :sonar-rust-plugin:compileTestJava :custom-rules-plugin:compileJava`
- reproduced the selective compile and runtime lock refresh with scanner-engine 13.8.0.4534
- confirmed all five scanner-engine lock entries move to 13.8.0.4534
- confirmed `:sonar-rust-plugin:compileTestJava` succeeds with scanner-engine 13.8.0.4534 and Java release 21
