### PR TITLE
RUST-690 Preserve Java 21 for Renovate post-upgrade tasks

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,14 +17,14 @@
         "java": "21"
       },
       "postUpgradeTasks": {
-        "executionMode": "branch",
+        "executionMode": "update",
         "installTools": {
           "java": {}
         },
         "commands": [
           "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 properties",
-          "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 --refresh-dependencies --update-locks {{#each (distinct (lookupArray upgrades \"depName\"))}}{{{.}}}{{#unless @last}},{{/unless}}{{/each}} :e2e:dependencies --configuration testCompileClasspath :sonar-rust-plugin:dependencies --configuration testCompileClasspath",
-          "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 --update-locks {{#each (distinct (lookupArray upgrades \"depName\"))}}{{{.}}}{{#unless @last}},{{/unless}}{{/each}} :e2e:dependencies --configuration testRuntimeClasspath :sonar-rust-plugin:dependencies --configuration testRuntimeClasspath",
+          "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 --refresh-dependencies --update-locks {{{depName}}} :e2e:dependencies --configuration testCompileClasspath :sonar-rust-plugin:dependencies --configuration testCompileClasspath",
+          "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 --update-locks {{{depName}}} :e2e:dependencies --configuration testRuntimeClasspath :sonar-rust-plugin:dependencies --configuration testRuntimeClasspath",
           "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 :sonar-rust-plugin:dependencies --configuration jacocoAgent",
           "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 :sonar-rust-plugin:dependencies --configuration jacocoAnt",
           "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 --no-configure-on-demand :sonar-rust-plugin:jacocoTestReport -x :sonar-rust-plugin:test"


### PR DESCRIPTION
Part of RUST-690

## Why

The self-hosted Renovate write run for #341 set renovate/artifacts to failure while executing the final Gradle post-upgrade task. Renovate 43.275.2 drops package constraints when post-upgrade tasks use branch execution mode, so installTools selected Java 26 instead of the configured Java 21. Gradle then could not locate the Java 21 toolchain required by sonar-rust.

## What

- run Gradle post-upgrade tasks in update mode so each update retains constraints.java = 21
- selectively unlock the dependency for the current update through depName
- keep the existing lockfile and verification-metadata refresh commands unchanged otherwise

## Validation

- jq empty .github/renovate.json
- npx --yes --package=renovate@43.275.2 renovate-config-validator .github/renovate.json
- ran the exact failing jacocoTestReport post-upgrade command successfully with Java 21
- confirmed the Gradle validation produced no lockfile or verification-metadata changes
- confirmed the regenerated #341 Unit Tests and Analysis job passes; its remaining red status is only renovate/artifacts