### PR TITLE
RUST-713 Separate Gradle wrapper artifact tasks

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,8 +10,7 @@
     {
       "description": "Refresh Gradle lockfiles and verification metadata after dependency updates",
       "matchManagers": [
-        "gradle",
-        "gradle-wrapper"
+        "gradle"
       ],
       "constraints": {
         "java": "21"
@@ -41,7 +40,29 @@
       "matchManagers": [
         "gradle-wrapper"
       ],
-      "skipArtifactsUpdate": true
+      "constraints": {
+        "java": "21"
+      },
+      "skipArtifactsUpdate": true,
+      "postUpgradeTasks": {
+        "executionMode": "update",
+        "installTools": {
+          "java": {}
+        },
+        "commands": [
+          "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 properties",
+          "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 --refresh-dependencies :e2e:dependencies --configuration testCompileClasspath :sonar-rust-plugin:dependencies --configuration testCompileClasspath",
+          "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 :e2e:dependencies --configuration testRuntimeClasspath :sonar-rust-plugin:dependencies --configuration testRuntimeClasspath",
+          "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 :sonar-rust-plugin:dependencies --configuration jacocoAgent",
+          "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 :sonar-rust-plugin:dependencies --configuration jacocoAnt",
+          "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 --no-configure-on-demand :sonar-rust-plugin:jacocoTestReport -x :sonar-rust-plugin:test"
+        ],
+        "fileFilters": [
+          "**/gradle.lockfile",
+          "**/settings-gradle.lockfile",
+          "gradle/verification-metadata.xml"
+        ]
+      }
     },
     {
       "matchManagers": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -50,6 +50,7 @@
           "java": {}
         },
         "commands": [
+          "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 :wrapper --gradle-version {{{newValue}}}",
           "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 properties",
           "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 --refresh-dependencies :e2e:dependencies --configuration testCompileClasspath :sonar-rust-plugin:dependencies --configuration testCompileClasspath",
           "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 :e2e:dependencies --configuration testRuntimeClasspath :sonar-rust-plugin:dependencies --configuration testRuntimeClasspath",
@@ -58,6 +59,10 @@
           "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 --no-configure-on-demand :sonar-rust-plugin:jacocoTestReport -x :sonar-rust-plugin:test"
         ],
         "fileFilters": [
+          "gradlew",
+          "gradlew.bat",
+          "gradle/wrapper/gradle-wrapper.jar",
+          "gradle/wrapper/gradle-wrapper.properties",
           "**/gradle.lockfile",
           "**/settings-gradle.lockfile",
           "gradle/verification-metadata.xml"


### PR DESCRIPTION
Relates to [RUST-713](https://sonarsource.atlassian.net/browse/RUST-713).

## Summary

- Separate Gradle dependency and Gradle Wrapper post-upgrade rules.
- Keep selective `--update-locks {{{depName}}}` handling for ordinary Gradle dependencies.
- Run the existing Java 21 wrapper validation without passing the wrapper dependency name to `--update-locks`.
- Regenerate `gradlew`, `gradlew.bat`, and `gradle-wrapper.jar` with the new Gradle version and retain those artifacts.

## Why

For Gradle Wrapper updates, Renovate renders `depName` as `gradle`. Gradle requires every `--update-locks` value to use `<group>:<artifact>` format, so the shared rule would produce an invalid `--update-locks gradle` command and mark `renovate/artifacts` as failed.

The wrapper-specific rule keeps `skipArtifactsUpdate` so Renovate's built-in artifact path cannot fail before the repository lock and verification tasks run. Its first repository task now runs `:wrapper --gradle-version {{{newValue}}}`, and its file filters retain the launcher scripts, wrapper JAR and properties alongside the lockfiles and verification metadata.

## Validation

- Parsed `.github/renovate.json` with Node.
- Asserted that the wrapper rule contains no `--update-locks` command and the dependency rule still does.
- Asserted that every wrapper command matches the central `allowedCommands` regex.
- Confirmed all four wrapper launcher files are tracked and present in `fileFilters`.
- `git diff --check`


[RUST-713]: https://sonarsource.atlassian.net/browse/RUST-713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ