### PR TITLE
RUST-729 Use Gradle package names in Renovate lock updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,8 +22,8 @@
         },
         "commands": [
           "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 properties",
-          "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 --refresh-dependencies --update-locks {{{depName}}} :e2e:dependencies --configuration testCompileClasspath :sonar-rust-plugin:dependencies --configuration testCompileClasspath",
-          "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 --update-locks {{{depName}}} :e2e:dependencies --configuration testRuntimeClasspath :sonar-rust-plugin:dependencies --configuration testRuntimeClasspath",
+          "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 --refresh-dependencies --update-locks {{{packageName}}} :e2e:dependencies --configuration testCompileClasspath :sonar-rust-plugin:dependencies --configuration testCompileClasspath",
+          "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 --update-locks {{{packageName}}} :e2e:dependencies --configuration testRuntimeClasspath :sonar-rust-plugin:dependencies --configuration testRuntimeClasspath",
           "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 :sonar-rust-plugin:dependencies --configuration jacocoAgent",
           "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 :sonar-rust-plugin:dependencies --configuration jacocoAnt",
           "./gradlew --no-daemon --console=plain --write-locks --write-verification-metadata sha256 --no-configure-on-demand :sonar-rust-plugin:jacocoTestReport -x :sonar-rust-plugin:test"


### PR DESCRIPTION
Part of

## What

- Use Renovate's `packageName` when passing dependency coordinates to Gradle's `--update-locks` option.

## Why

For Gradle plugins, Renovate's `depName` is the plugin ID, such as `com.diffplug.spotless`, which Gradle rejects because `--update-locks` requires a `group:artifact` coordinate. Renovate's `packageName` contains the complete plugin marker coordinate while remaining identical to `depName` for ordinary Maven dependencies.

This allows Renovate to refresh lockfiles for both plugin and library updates without reporting an artifact update failure.

## Validation

- Renovate configuration validation passes with Renovate 43.275.2.
- Both affected post-upgrade Gradle commands complete successfully with `com.diffplug.spotless:com.diffplug.spotless.gradle.plugin`.
- The validation commands leave the existing lockfiles and verification metadata unchanged.
