### PR TITLE
RUST-781 Remove redundant logging dependency handling

### DIFF
--- a/e2e/build.gradle.kts
+++ b/e2e/build.gradle.kts
@@ -19,6 +19,9 @@ dependencies {
 
     // Force specific versions of transitive dependencies
     constraints {
+      implementation("ch.qos.logback:logback-classic:1.6.3") {
+        because("orchestrator pins logback 1.5.37; keep aligned with the Plugin API v14 logging stack")
+      }
       implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.22.2") {
         because("CVE-2020-36518 - Out-of-bounds Write")
       }

--- a/e2e/build.gradle.kts
+++ b/e2e/build.gradle.kts
@@ -19,9 +19,6 @@ dependencies {
 
     // Force specific versions of transitive dependencies
     constraints {
-      implementation("ch.qos.logback:logback-classic:1.6.3") {
-        because("CVE-2023-6378 - Deserialization of Untrusted Data")
-      }
       implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.22.2") {
         because("CVE-2020-36518 - Out-of-bounds Write")
       }

--- a/sonar-rust-plugin/build.gradle.kts
+++ b/sonar-rust-plugin/build.gradle.kts
@@ -44,12 +44,6 @@ dependencies {
   testImplementation("org.awaitility:awaitility:4.3.0")
   testRuntimeOnly(libs.junit.platform.launcher)
   
-  // Force specific versions of transitive dependencies
-  constraints {
-    implementation("ch.qos.logback:logback-classic:1.6.3") {
-      because("CVE-2023-6378 - Deserialization of Untrusted Data")
-    }
-  }
 }
 
 // Apply a specific Java toolchain to ease working on different environments.


### PR DESCRIPTION
Part of

## Summary

- Remove redundant SLF4J and Logback handling from the Plugin API-backed analyzer module.
- Rely on Sonar Plugin API v14 and its test fixtures for SLF4J 2.0.18 and Logback 1.6.3 there.
- Retain the e2e Logback constraint because that standalone project receives Logback 1.5.37 from Orchestrator and locks 1.6.3.

## Validation

- `./gradlew :e2e:dependencyInsight --dependency logback-classic --configuration testRuntimeClasspath`
- e2e resolves Logback 1.6.3 with dependency locking intact.
