### PR TITLE
BUILD-12307 Migrate eligible jobs to self-hosted runners

### DIFF
--- a/.github/workflows/ShadowScans.yml
+++ b/.github/workflows/ShadowScans.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: github-ubuntu-latest-m
+    runs-on: sonar-m
     name: Build for Shadow Scan
     permissions:
       id-token: write
@@ -45,7 +45,7 @@ jobs:
     concurrency:
       group: iris-${{ github.ref }}
       cancel-in-progress: false
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     name: Run IRIS
     permissions:
       id-token: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
           path: analyzer/target/x86_64-apple-darwin/release/analyzer.xz
 
   cross_platform_analyzers:
-    runs-on: github-ubuntu-latest-m
+    runs-on: warp-custom-ubuntu-24-04
     name: Cross-Platform Analyzers Build
     env:
       MUSL_CROSS_MAKE_COMMIT: 6f3701d08137496d5aac479e3a3977b5ae993c1f
@@ -132,7 +132,7 @@ jobs:
           path: analyzer/target/x86_64-pc-windows-gnu/release/analyzer.exe.xz
 
   unit_test_and_analysis:
-    runs-on: github-ubuntu-latest-m
+    runs-on: sonar-m
     name: Unit Tests and Analysis
     permissions:
       id-token: write
@@ -164,7 +164,7 @@ jobs:
       !cancelled() &&
       (needs.macos_analyzers.result == 'success' || needs.macos_analyzers.result == 'skipped') &&
       needs.cross_platform_analyzers.result == 'success'
-    runs-on: github-ubuntu-latest-m
+    runs-on: sonar-m
     name: Build
     permissions:
       id-token: write
@@ -216,7 +216,7 @@ jobs:
   e2e:
     needs: [build]
     if: ${{ !cancelled() && needs.build.result == 'success' }}
-    runs-on: github-ubuntu-latest-m
+    runs-on: sonar-m
     name: E2E Tests
     permissions:
       id-token: write
@@ -247,7 +247,7 @@ jobs:
   e2e_win:
     needs: [build]
     if: ${{ !cancelled() && needs.build.result == 'success' }}
-    runs-on: github-windows-latest-m
+    runs-on: warp-custom-windows-2022-m
     name: E2E Tests Windows
     permissions:
       id-token: write
@@ -340,7 +340,7 @@ jobs:
       startsWith(github.ref_name, 'dogfood-'))
     permissions:
       id-token: write
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     steps:
       # https://github.com/SonarSource/release-github-actions/tree/master/notify-slack
       - uses: SonarSource/release-github-actions/notify-slack@v1
@@ -359,7 +359,7 @@ jobs:
       needs.e2e.result == 'success' &&
       needs.e2e_win.result == 'success' &&
       needs.e2e_linux_arm64.result == 'success'
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     name: Promote
     permissions:
       id-token: write

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   bump-version:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/lock-branch.yaml
+++ b/.github/workflows/lock-branch.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   lock-branch:
     name: Toggle lock branch
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/mark-prs-stale.yml
+++ b/.github/workflows/mark-prs-stale.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   stale:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/releasability.yml
+++ b/.github/workflows/releasability.yml
@@ -5,7 +5,7 @@ name: Releasability status
       - completed
 jobs:
   update_releasability_status:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     name: Releasability status
     permissions:
       id-token: write

--- a/.github/workflows/update-clippy-metadata.yml
+++ b/.github/workflows/update-clippy-metadata.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   update:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
BUILD-12307

## Purpose
Self-hosted runners should be used in all cases except approved use cases where self-hosted runners do not work. They are more cost-efficient and faster than GitHub-hosted runners.

This PR migrates eligible Linux and Windows workflow jobs to SonarSource self-hosted runner labels, using right-sized runners for automation, build, test, promotion, and cross-platform jobs.

## Retained jobs
- The macOS analyzer build remains on GitHub-hosted macOS because there is no supported self-hosted macOS equivalent.
- The Linux ARM64 E2E job remains hosted pending confirmation of compatible self-hosted ARM64 capacity.

The owning squad should validate these retained cases against the approved exceptions before merging.

## Validation
- `git diff --check`
- Scoped `actionlint`; passed after excluding expected unknown-label diagnostics for SonarSource custom runner labels and unrelated pre-existing shellcheck findings.

## Tracking
- Subtask: https://sonarsource.atlassian.net/browse/BUILD-12307
- Parent: https://sonarsource.atlassian.net/browse/BUILD-12470
- Migration initiative: https://sonarsource.atlassian.net/browse/BUILD-12260

Owning squad: please take over final workflow validation and merge this PR. Let us know if you encounter any issues.